### PR TITLE
fix: board view not grouping by status columns

### DIFF
--- a/src/components/DatabaseBoard.tsx
+++ b/src/components/DatabaseBoard.tsx
@@ -4,7 +4,7 @@ import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
 import {
 	DatabaseConfig, DEFAULT_DATABASE_CONFIG,
-	FilterOperator, NoteRow, ViewConfig,
+	FilterOperator, NoteRow, SelectOption, ViewConfig,
 } from '../types'
 import { evaluateFormulas } from '../formula-engine'
 import {
@@ -165,9 +165,18 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 		[config.schema, activeView.hiddenColumns, groupByCol]
 	)
 
+	const DEFAULT_STATUS_OPTIONS: SelectOption[] = [
+		{ value: t('status_not_started'), color: '#9E9E9E' },
+		{ value: t('status_in_progress'), color: '#2196F3' },
+		{ value: t('status_done'), color: '#4CAF50' },
+		{ value: t('status_cancelled'), color: '#F44336' },
+	]
+
 	const columns = useMemo(() => {
 		if (!groupByCol) return []
-		const options = groupByCol.options ?? []
+		const options = (groupByCol.type === 'status' && !groupByCol.options?.length)
+			? DEFAULT_STATUS_OPTIONS
+			: (groupByCol.options ?? [])
 		const all = [
 			...options.map(opt => ({
 				value: opt.value,

--- a/src/database-manager.ts
+++ b/src/database-manager.ts
@@ -248,7 +248,7 @@ export class DatabaseManager {
 
 		return Array.from(fieldMap.entries()).map(([key, values]) => {
 			const type = this.inferType(key, values)
-			const options = (type === 'select' || type === 'multiselect')
+			const options = (type === 'select' || type === 'multiselect' || type === 'status')
 				? this.extractOptions(values, type)
 				: undefined
 


### PR DESCRIPTION
## Summary
- Include `status` type in option extraction during schema inference (was only `select` and `multiselect`)
- Add `DEFAULT_STATUS_OPTIONS` fallback in board view for status columns without user-defined options

Closes #4

## Test plan
- [ ] Create a database with notes containing a `status` property
- [ ] Open Board/Kanban view and group by the status column
- [ ] Verify kanban columns appear with the correct status values
- [ ] Verify cards are placed in the correct columns
- [ ] Test with both inferred and manually created status columns