### PR TITLE
fix: prevent views reset when editing database properties

### DIFF
--- a/src/hooks/useDatabaseRows.ts
+++ b/src/hooks/useDatabaseRows.ts
@@ -133,7 +133,7 @@ export function useDatabaseRows(options: UseDatabaseRowsOptions): UseDatabaseRow
 			setActiveFilters(restoreFilterPills(pills, cfg.schema))
 		}
 
-		setConfig(prev => ({ schema: cfg.schema, views: prev.views }))
+		setConfig({ schema: cfg.schema, views: cfg.views })
 		setRows(noteRows)
 		onLoaded?.(cfg, noteRows)
 		setLoading(false)


### PR DESCRIPTION
## Summary
- Fixes #14 — custom views were being wiped and renamed back to "Table" whenever a property was edited
- Root cause: `useDatabaseRows` preserved `prev.views` in local state (stuck at `[DEFAULT_VIEW]`) instead of syncing `cfg.views` from disk. Any `writeConfig` call from `DatabaseTable` (updateSchema / renameColumn / saveView) persisted that stale array, overwriting real views
- One-line fix in `src/hooks/useDatabaseRows.ts:136`

## Test plan
- [x] Unit tests pass (135/135)
- [x] Manual QA in clean vault reproducing exact repro steps from issue:
  - [x] Added Board view — persists (no split-second disappear)
  - [x] Renamed default Table view — custom name preserved after schema edits
  - [x] Changed column type — both views intact
  - [x] Renamed column — both views and custom names preserved

Closes #14