### PR TITLE
feat: per-database row templates with optional picker on create

### DIFF
--- a/src/components/DatabaseBoard.tsx
+++ b/src/components/DatabaseBoard.tsx
@@ -473,7 +473,7 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 
 	const addCardToColumn = useCallback(async (columnValue: string) => {
 		if (!dbFile || !groupByCol) return
-		const newFile = await manager.createNote(dbFile)
+		const newFile = await manager.createNoteWithTemplate(dbFile)
 		if (columnValue !== '') {
 			await trackSave(app.fileManager.processFrontMatter(newFile, (fm: Record<string, unknown>) => {
 				fm[groupByCol.id] = columnValue

--- a/src/components/DatabaseCalendar.tsx
+++ b/src/components/DatabaseCalendar.tsx
@@ -324,7 +324,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 
 	const handleDayClick = async (year: number, month: number, day: number) => {
 		if (!dbFile || !dateField) return
-		const newFile = await manager.createNote(dbFile)
+		const newFile = await manager.createNoteWithTemplate(dbFile)
 		const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
 		await trackSave(app.fileManager.processFrontMatter(newFile, (fm: Record<string, unknown>) => { fm[dateField.id] = dateStr }))
 	}

--- a/src/components/DatabaseGallery.tsx
+++ b/src/components/DatabaseGallery.tsx
@@ -305,7 +305,7 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 		await saveView({ ...activeView, sorts: newSorts })
 	}, [activeView, saveView])
 
-	const handleAddRow = async () => { if (dbFile) await manager.createNote(dbFile) }
+	const handleAddRow = async () => { if (dbFile) await manager.createNoteWithTemplate(dbFile) }
 
 	// ── Render ───────────────────────────────────────────────────────────────
 

--- a/src/components/DatabaseList.tsx
+++ b/src/components/DatabaseList.tsx
@@ -299,7 +299,7 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 		await saveView({ ...activeView, sorts: newSorts })
 	}, [activeView, saveView])
 
-	const handleAddRow = async () => { if (dbFile) await manager.createNote(dbFile) }
+	const handleAddRow = async () => { if (dbFile) await manager.createNoteWithTemplate(dbFile) }
 
 	// ── Hierarchy state ───────────────────────────────────────────────────────
 

--- a/src/components/DatabaseRoot.tsx
+++ b/src/components/DatabaseRoot.tsx
@@ -2,6 +2,7 @@ import { TFile } from 'obsidian'
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
+import { DatabaseSettingsModal } from '../database-settings-modal'
 import { DatabaseConfig, DEFAULT_DATABASE_CONFIG, DEFAULT_VIEW, EmbedState, ViewConfig } from '../types'
 import { DatabaseTable } from './DatabaseTable'
 import { DatabaseList } from './DatabaseList'
@@ -408,6 +409,20 @@ export function DatabaseRoot({
 						</div>
 					)}
 				</div>
+				<button
+					className="nb-view-tab-settings-btn"
+					title={t('db_settings_open')}
+					onClick={() => {
+						if (!dbFile) return
+						new DatabaseSettingsModal(app, config, async (updated) => {
+							const newConfig = { ...config, ...updated }
+							setConfig(newConfig)
+							await manager.writeConfig(dbFile, newConfig)
+						}).open()
+					}}
+				>
+					⚙
+				</button>
 			</div>
 			{activeView.type === 'table'
 				? <DatabaseTable

--- a/src/components/DatabaseTable.tsx
+++ b/src/components/DatabaseTable.tsx
@@ -527,7 +527,7 @@ function SortPanel({ sorts, schema, onSortChange, onClose, anchorRect, panelRef 
 		</div>,
 		document.body
 	)
-}
+}
 
 function ResizeHandle({ onResize, onAutoFit }: { onResize: (w: number) => void; onAutoFit?: () => void }) {
 	const handleMouseDown = (e: React.MouseEvent) => {
@@ -1226,14 +1226,14 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 
 	const handleAddRow = async () => {
 		if (!dbFile) return
-		const newFile = await manager.createNote(dbFile)
+		const newFile = await manager.createNoteWithTemplate(dbFile)
 		lastCreatedPath.current = newFile.path
 		// loadData será chamado pelo evento vault.on('create')
 	}
 
 	const handleAddSubRow = useCallback(async (parentTitle: string) => {
 		if (!dbFile || !hierarchyCol) return
-		const newFile = await manager.createNote(dbFile, { [hierarchyCol.id]: [parentTitle] })
+		const newFile = await manager.createNoteWithTemplate(dbFile, { [hierarchyCol.id]: [parentTitle] })
 		lastCreatedPath.current = newFile.path
 	}, [dbFile, hierarchyCol, manager])
 

--- a/src/database-manager.ts
+++ b/src/database-manager.ts
@@ -12,6 +12,7 @@ import {
 	ViewConfig,
 } from './types'
 import { parseInlineFields, frontmatterLineCount } from './inline-fields'
+import { TemplatePickerModal } from './template-picker-modal'
 
 export const DATABASE_MARKER = 'notion-bases'
 
@@ -55,6 +56,8 @@ export class DatabaseManager {
 		return {
 			schema,
 			views: Array.isArray(fm['views']) && (fm['views'] as unknown[]).length > 0 ? fm['views'] as ViewConfig[] : [DEFAULT_VIEW],
+			templatePath: typeof fm['templatePath'] === 'string' && fm['templatePath'] ? fm['templatePath'] : undefined,
+			askTemplateOnCreate: fm['askTemplateOnCreate'] === true,
 		}
 	}
 
@@ -63,6 +66,10 @@ export class DatabaseManager {
 			fm[DATABASE_MARKER] = true
 			fm['schema'] = config.schema
 			fm['views'] = config.views
+			if (config.templatePath) fm['templatePath'] = config.templatePath
+			else delete fm['templatePath']
+			if (config.askTemplateOnCreate) fm['askTemplateOnCreate'] = true
+			else delete fm['askTemplateOnCreate']
 		})
 	}
 
@@ -292,7 +299,11 @@ export class DatabaseManager {
 		await this.app.fileManager.renameFile(file, newPath)
 	}
 
-	async createNote(dbFile: TFile, initialFrontmatter?: Record<string, unknown>): Promise<TFile> {
+	async createNote(
+		dbFile: TFile,
+		initialFrontmatter?: Record<string, unknown>,
+		templatePath?: string | null,
+	): Promise<TFile> {
 		const folderPath = dbFile.parent?.path ?? ''
 		const base = normalizePath(`${folderPath}/${t('db_untitled_note')}`)
 		let path = `${base}.md`
@@ -308,7 +319,54 @@ export class DatabaseManager {
 				}
 			})
 		}
+		if (templatePath) {
+			await this.applyTemplate(newFile, templatePath)
+		}
 		return newFile
+	}
+
+	/** createNote + automatic template resolution based on db config. Opens picker if askTemplateOnCreate is on. */
+	async createNoteWithTemplate(dbFile: TFile, initialFrontmatter?: Record<string, unknown>): Promise<TFile> {
+		const config = this.readConfig(dbFile)
+		if (config.askTemplateOnCreate) {
+			const templatePath = await new Promise<string | null>(resolve => {
+				new TemplatePickerModal(this.app, (path) => resolve(path), config.templatePath ? this.folderOf(config.templatePath) : null).open()
+			})
+			return this.createNote(dbFile, initialFrontmatter, templatePath)
+		}
+		return this.createNote(dbFile, initialFrontmatter, config.templatePath ?? null)
+	}
+
+	private folderOf(path: string): string | null {
+		const idx = path.lastIndexOf('/')
+		return idx > 0 ? path.slice(0, idx) : null
+	}
+
+	/** Append template body to a note, substituting {{title}}, {{date}}, {{time}}, {{folder}}. */
+	async applyTemplate(targetFile: TFile, templatePath: string): Promise<void> {
+		const templateFile = this.app.vault.getFileByPath(normalizePath(templatePath))
+		if (!templateFile) return
+
+		const raw = await this.app.vault.read(templateFile)
+		// Strip the template's own frontmatter if present — row frontmatter is authoritative
+		const body = raw.replace(/^---\n[\s\S]*?\n---\n?/, '')
+		if (!body.trim()) return
+
+		const moment = (window as unknown as { moment?: (d?: Date) => { format: (fmt: string) => string } }).moment
+		const now = new Date()
+		const fmtDate = (fmt: string) => moment ? moment(now).format(fmt) : now.toISOString().slice(0, 10)
+		const fmtTime = (fmt: string) => moment ? moment(now).format(fmt) : now.toTimeString().slice(0, 5)
+
+		const processed = body
+			.replace(/\{\{title\}\}/g, targetFile.basename)
+			.replace(/\{\{folder\}\}/g, targetFile.parent?.path ?? '')
+			.replace(/\{\{date:([^}]+)\}\}/g, (_m, f) => fmtDate(String(f)))
+			.replace(/\{\{time:([^}]+)\}\}/g, (_m, f) => fmtTime(String(f)))
+			.replace(/\{\{date\}\}/g, fmtDate('YYYY-MM-DD'))
+			.replace(/\{\{time\}\}/g, fmtTime('HH:mm'))
+
+		const current = await this.app.vault.read(targetFile)
+		await this.app.vault.modify(targetFile, current + processed)
 	}
 
 	// ── Lookup helpers ─────────────────────────────────────────────────────

--- a/src/database-settings-modal.ts
+++ b/src/database-settings-modal.ts
@@ -1,0 +1,75 @@
+import { App, Modal, Setting } from 'obsidian'
+import { DatabaseConfig } from './types'
+import { TemplatePickerModal } from './template-picker-modal'
+import { t } from './i18n'
+
+export class DatabaseSettingsModal extends Modal {
+	private config: DatabaseConfig
+	private onSave: (updated: { templatePath?: string; askTemplateOnCreate?: boolean }) => Promise<void> | void
+
+	constructor(
+		app: App,
+		config: DatabaseConfig,
+		onSave: (updated: { templatePath?: string; askTemplateOnCreate?: boolean }) => Promise<void> | void,
+	) {
+		super(app)
+		this.config = config
+		this.onSave = onSave
+	}
+
+	onOpen(): void {
+		const { contentEl } = this
+		contentEl.empty()
+		contentEl.createEl('h2', { text: t('db_settings_title') })
+
+		// ── Template path ─────────────────────────────────────────────────
+		const tplSetting = new Setting(contentEl)
+			.setName(t('db_settings_template_name'))
+			.setDesc(t('db_settings_template_desc'))
+
+		const pathEl = contentEl.createDiv({ cls: 'nb-db-settings-template-path' })
+		const renderPath = () => {
+			pathEl.empty()
+			pathEl.setText(this.config.templatePath ?? t('db_settings_template_none'))
+		}
+		renderPath()
+
+		tplSetting.addButton(btn => btn
+			.setButtonText(t('db_settings_template_choose'))
+			.onClick(() => {
+				new TemplatePickerModal(this.app, (path) => {
+					this.config = { ...this.config, templatePath: path ?? undefined }
+					renderPath()
+					void this.onSave({ templatePath: this.config.templatePath })
+				}).open()
+			}))
+
+		if (this.config.templatePath) {
+			tplSetting.addExtraButton(btn => btn
+				.setIcon('x')
+				.setTooltip(t('db_settings_template_clear'))
+				.onClick(async () => {
+					this.config = { ...this.config, templatePath: undefined }
+					renderPath()
+					await this.onSave({ templatePath: undefined })
+					// Re-render modal so the clear button disappears
+					this.onOpen()
+				}))
+		}
+
+		// ── Ask on create toggle ──────────────────────────────────────────
+		new Setting(contentEl)
+			.setName(t('db_settings_ask_name'))
+			.setDesc(t('db_settings_ask_desc'))
+			.addToggle(tg => tg
+				.setValue(!!this.config.askTemplateOnCreate)
+				.onChange(async (v) => {
+					this.config = { ...this.config, askTemplateOnCreate: v }
+					await this.onSave({ askTemplateOnCreate: v })
+				}))
+	}
+
+	onClose(): void {
+		this.contentEl.empty()
+	}
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -475,6 +475,19 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	save: 'Speichern',
 	cancel: 'Abbrechen',
 	value: 'Wert',
+
+	// Database settings modal (row templates)
+	db_settings_open: 'Datenbankeinstellungen',
+	db_settings_title: 'Datenbankeinstellungen',
+	db_settings_template_name: 'Zeilenvorlage',
+	db_settings_template_desc: 'Wendet diese Vorlage auf den Inhalt jeder neuen Zeile in dieser Datenbank an.',
+	db_settings_template_choose: 'Vorlage wählen',
+	db_settings_template_clear: 'Vorlage entfernen',
+	db_settings_template_none: 'Keine Vorlage ausgewählt',
+	db_settings_ask_name: 'Vorlage beim Erstellen abfragen',
+	db_settings_ask_desc: 'Bei jeder neuen Zeile nach einer Vorlage fragen, anstatt die Standardvorlage anzuwenden.',
+	template_picker_placeholder: 'Vorlage auswählen...',
+	template_picker_none: 'Keine Vorlage (leerer Inhalt)',
 }
 
 export default de

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -473,6 +473,19 @@ const en = {
 	save: 'Save',
 	cancel: 'Cancel',
 	value: 'Value',
+
+	// Database settings modal (row templates)
+	db_settings_open: 'Database settings',
+	db_settings_title: 'Database settings',
+	db_settings_template_name: 'Row template',
+	db_settings_template_desc: 'Apply this template to the body of every new row created in this database.',
+	db_settings_template_choose: 'Choose template',
+	db_settings_template_clear: 'Clear template',
+	db_settings_template_none: 'No template selected',
+	db_settings_ask_name: 'Ask for template on create',
+	db_settings_ask_desc: 'Prompt for a template each time a new row is added instead of applying the default.',
+	template_picker_placeholder: 'Choose a template...',
+	template_picker_none: 'No template (empty body)',
 } as const
 
 export default en

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -475,6 +475,19 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	save: 'Guardar',
 	cancel: 'Cancelar',
 	value: 'Valor',
+
+	// Database settings modal (row templates)
+	db_settings_open: 'Configuración de la base de datos',
+	db_settings_title: 'Configuración de la base de datos',
+	db_settings_template_name: 'Plantilla de fila',
+	db_settings_template_desc: 'Aplica esta plantilla al cuerpo de cada nueva fila creada en esta base de datos.',
+	db_settings_template_choose: 'Elegir plantilla',
+	db_settings_template_clear: 'Quitar plantilla',
+	db_settings_template_none: 'Sin plantilla seleccionada',
+	db_settings_ask_name: 'Pedir plantilla al crear',
+	db_settings_ask_desc: 'Solicitar una plantilla cada vez que se añada una nueva fila en lugar de aplicar la predeterminada.',
+	template_picker_placeholder: 'Elige una plantilla...',
+	template_picker_none: 'Sin plantilla (cuerpo vacío)',
 }
 
 export default es

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -475,6 +475,19 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	save: 'Enregistrer',
 	cancel: 'Annuler',
 	value: 'Valeur',
+
+	// Database settings modal (row templates)
+	db_settings_open: 'Paramètres de la base de données',
+	db_settings_title: 'Paramètres de la base de données',
+	db_settings_template_name: 'Modèle de ligne',
+	db_settings_template_desc: 'Applique ce modèle au corps de chaque nouvelle ligne créée dans cette base de données.',
+	db_settings_template_choose: 'Choisir un modèle',
+	db_settings_template_clear: 'Effacer le modèle',
+	db_settings_template_none: 'Aucun modèle sélectionné',
+	db_settings_ask_name: 'Demander un modèle à la création',
+	db_settings_ask_desc: 'Demander un modèle à chaque ajout de ligne au lieu d\'appliquer celui par défaut.',
+	template_picker_placeholder: 'Choisir un modèle...',
+	template_picker_none: 'Aucun modèle (corps vide)',
 }
 
 export default fr

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -475,6 +475,19 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	save: '保存',
 	cancel: 'キャンセル',
 	value: '値',
+
+	// Database settings modal (row templates)
+	db_settings_open: 'データベース設定',
+	db_settings_title: 'データベース設定',
+	db_settings_template_name: '行テンプレート',
+	db_settings_template_desc: 'このデータベースに新しく作成されるすべての行の本文にこのテンプレートを適用します。',
+	db_settings_template_choose: 'テンプレートを選択',
+	db_settings_template_clear: 'テンプレートを削除',
+	db_settings_template_none: 'テンプレートが選択されていません',
+	db_settings_ask_name: '作成時にテンプレートを確認する',
+	db_settings_ask_desc: 'デフォルトを適用する代わりに、新しい行を追加するたびにテンプレートを選択するよう促します。',
+	template_picker_placeholder: 'テンプレートを選択...',
+	template_picker_none: 'テンプレートなし（本文を空にする）',
 }
 
 export default ja

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -475,6 +475,19 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	save: 'Salvar',
 	cancel: 'Cancelar',
 	value: 'Valor',
+
+	// Database settings modal (row templates)
+	db_settings_open: 'Configurações do banco de dados',
+	db_settings_title: 'Configurações do banco de dados',
+	db_settings_template_name: 'Modelo de linha',
+	db_settings_template_desc: 'Aplica este modelo ao corpo de cada nova linha criada neste banco de dados.',
+	db_settings_template_choose: 'Escolher modelo',
+	db_settings_template_clear: 'Remover modelo',
+	db_settings_template_none: 'Nenhum modelo selecionado',
+	db_settings_ask_name: 'Perguntar pelo modelo ao criar',
+	db_settings_ask_desc: 'Solicitar um modelo toda vez que uma nova linha for adicionada, em vez de usar o padrão.',
+	template_picker_placeholder: 'Escolha um modelo...',
+	template_picker_none: 'Sem modelo (corpo vazio)',
 }
 
 export default ptBR

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -475,6 +475,19 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	save: '保存',
 	cancel: '取消',
 	value: '值',
+
+	// Database settings modal (row templates)
+	db_settings_open: '数据库设置',
+	db_settings_title: '数据库设置',
+	db_settings_template_name: '行模板',
+	db_settings_template_desc: '将此模板应用于在此数据库中创建的每一新行的正文。',
+	db_settings_template_choose: '选择模板',
+	db_settings_template_clear: '清除模板',
+	db_settings_template_none: '未选择模板',
+	db_settings_ask_name: '创建时询问模板',
+	db_settings_ask_desc: '每次添加新行时提示选择模板，而不是应用默认模板。',
+	template_picker_placeholder: '选择一个模板...',
+	template_picker_none: '无模板（空正文）',
 }
 
 export default zh

--- a/src/quick-add-modal.ts
+++ b/src/quick-add-modal.ts
@@ -156,7 +156,7 @@ export class QuickAddModal extends Modal {
 		}
 
 		try {
-			const newFile = await this.manager.createNote(this.dbFile, frontmatter)
+			const newFile = await this.manager.createNoteWithTemplate(this.dbFile, frontmatter)
 
 			// Rename if title was provided
 			if (this.titleValue.trim()) {

--- a/src/template-picker-modal.ts
+++ b/src/template-picker-modal.ts
@@ -1,0 +1,49 @@
+import { App, FuzzySuggestModal, TFile } from 'obsidian'
+import { t } from './i18n'
+
+type TemplateChoice = { file: TFile | null; label: string }
+
+export class TemplatePickerModal extends FuzzySuggestModal<TemplateChoice> {
+	private onChoose: (path: string | null) => void
+	private preferredFolder: string | null
+
+	constructor(app: App, onChoose: (path: string | null) => void, preferredFolder?: string | null) {
+		super(app)
+		this.onChoose = onChoose
+		this.preferredFolder = preferredFolder ?? this.getCoreTemplatesFolder()
+		this.setPlaceholder(t('template_picker_placeholder'))
+	}
+
+	private getCoreTemplatesFolder(): string | null {
+		const internalPlugins = (this.app as unknown as { internalPlugins?: { plugins?: Record<string, { instance?: { options?: { folder?: string } } }> } }).internalPlugins
+		const folder = internalPlugins?.plugins?.['templates']?.instance?.options?.folder
+		return typeof folder === 'string' && folder ? folder : null
+	}
+
+	getItems(): TemplateChoice[] {
+		const clear: TemplateChoice = { file: null, label: t('template_picker_none') }
+		const files = this.app.vault.getMarkdownFiles().filter(f => {
+			const cache = this.app.metadataCache.getFileCache(f)
+			return cache?.frontmatter?.['notion-bases'] !== true
+		})
+		const preferred = this.preferredFolder
+			? files.filter(f => f.path.startsWith(`${this.preferredFolder!}/`))
+			: []
+		const others = preferred.length > 0
+			? files.filter(f => !preferred.includes(f))
+			: files
+		const sorted = [
+			...preferred.sort((a, b) => a.path.localeCompare(b.path)),
+			...others.sort((a, b) => a.path.localeCompare(b.path)),
+		]
+		return [clear, ...sorted.map(f => ({ file: f, label: f.path }))]
+	}
+
+	getItemText(item: TemplateChoice): string {
+		return item.label
+	}
+
+	onChooseItem(item: TemplateChoice): void {
+		this.onChoose(item.file?.path ?? null)
+	}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,8 @@ export interface EmbedState {
 export interface DatabaseConfig {
 	schema: ColumnSchema[]
 	views: ViewConfig[]
+	templatePath?: string
+	askTemplateOnCreate?: boolean
 }
 
 export const DEFAULT_VIEW: ViewConfig = {

--- a/styles.css
+++ b/styles.css
@@ -2451,6 +2451,41 @@
 	background: var(--background-modifier-hover);
 }
 
+.nb-view-tab-settings-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	margin-left: auto;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	font-size: 14px;
+	cursor: pointer;
+	border-radius: var(--radius-s);
+}
+
+.nb-view-tab-settings-btn:hover {
+	color: var(--text-normal);
+	background: var(--background-modifier-hover);
+}
+
+.is-mobile .nb-view-tab-settings-btn {
+	min-width: 40px;
+	min-height: 40px;
+}
+
+.nb-db-settings-template-path {
+	margin: 4px 0 12px 0;
+	padding: 6px 10px;
+	font-size: 0.85em;
+	color: var(--text-muted);
+	background: var(--background-secondary);
+	border-radius: var(--radius-s);
+	word-break: break-all;
+}
+
 .nb-view-add-menu {
 	position: absolute;
 	top: calc(100% + 4px);


### PR DESCRIPTION
## Summary
- Closes #15 — adds a template system per database with two modes:
  - Fixed template applied automatically on row creation
  - Ask on create mode — fuzzy picker appears per row
- New gear icon in the view-tabs bar opens a Database settings modal
- Template body supports `{{title}}`, `{{date}}`, `{{time}}`, `{{folder}}` plus moment formats like `{{date:DD/MM/YYYY}}`
- Config persists in `_database.md` frontmatter (`templatePath`, `askTemplateOnCreate`)
- CSV import intentionally bypasses the template flow to avoid per-row prompts
- Template picker hides other databases' config files

## Test plan
- [x] Fixed template: new row applies template body with substituted variables
- [x] Ask on create: picker appears, supports "No template" option
- [x] Clearing template returns to empty-body default (backwards compatible)
- [x] 7 locales updated (en, pt-BR, es, fr, de, zh, ja)
- [x] Unit tests pass (135/135)
- [x] Build clean
- [ ] Beta testing via BRAT by the feature requester

Closes #15