### PR TITLE
feat: add folder context menu to create database

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -446,6 +446,7 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	// Commands
 	cmd_open_database: 'Datenbank für diesen Ordner öffnen',
 	cmd_create_database: 'Neue Datenbank im aktuellen Ordner erstellen',
+	ctx_create_database: 'Datenbank hier erstellen',
 
 	// Quick add
 	cmd_quick_add: 'Zeile schnell zur Datenbank hinzufügen',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -444,6 +444,7 @@ const en = {
 	// Commands
 	cmd_open_database: 'Open database for this folder',
 	cmd_create_database: 'Create new database in current folder',
+	ctx_create_database: 'Create database here',
 
 	// Quick add
 	cmd_quick_add: 'Quick add row to database',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -446,6 +446,7 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	// Commands
 	cmd_open_database: 'Abrir base de datos de esta carpeta',
 	cmd_create_database: 'Crear nueva base de datos en la carpeta actual',
+	ctx_create_database: 'Crear base de datos aquí',
 
 	// Quick add
 	cmd_quick_add: 'Añadir fila rápidamente a la base de datos',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -446,6 +446,7 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	// Commands
 	cmd_open_database: 'Ouvrir la base de données de ce dossier',
 	cmd_create_database: 'Créer une nouvelle base de données dans le dossier actuel',
+	ctx_create_database: 'Créer une base de données ici',
 
 	// Quick add
 	cmd_quick_add: 'Ajouter rapidement une ligne à la base de données',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -446,6 +446,7 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	// Commands
 	cmd_open_database: 'このフォルダーのデータベースを開く',
 	cmd_create_database: '現在のフォルダーに新しいデータベースを作成',
+	ctx_create_database: 'ここにデータベースを作成',
 
 	// Quick add
 	cmd_quick_add: 'データベースに行をすばやく追加',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -446,6 +446,7 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	// Commands
 	cmd_open_database: 'Abrir banco de dados desta pasta',
 	cmd_create_database: 'Criar novo banco de dados na pasta atual',
+	ctx_create_database: 'Criar banco de dados aqui',
 
 	// Quick add
 	cmd_quick_add: 'Adicionar linha rapidamente ao banco de dados',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -446,6 +446,7 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	// Commands
 	cmd_open_database: '打开此文件夹的数据库',
 	cmd_create_database: '在当前文件夹创建新数据库',
+	ctx_create_database: '在此处创建数据库',
 
 	// Quick add
 	cmd_quick_add: '快速向数据库添加行',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { MarkdownView, Notice, Plugin, TFile, WorkspaceLeaf } from 'obsidian'
+import { MarkdownView, Notice, Plugin, TFile, TFolder, WorkspaceLeaf } from 'obsidian'
 import { t } from './i18n'
 import { DATABASE_VIEW_TYPE, DatabaseView } from './database-view'
 import { DatabaseManager } from './database-manager'
@@ -94,6 +94,22 @@ export default class NotionBasesPlugin extends Plugin {
 						this._redirecting = false
 					}
 				}
+			})
+		)
+
+		// Menu de contexto do explorador de arquivos — "Create database here" em pastas
+		this.registerEvent(
+			this.app.workspace.on('file-menu', (menu, abstractFile) => {
+				if (!(abstractFile instanceof TFolder)) return
+				if (this.manager.getDatabaseFileInFolder(abstractFile.path)) return
+				menu.addItem(item => {
+					item
+						.setTitle(t('ctx_create_database'))
+						.setIcon('database')
+						.onClick(async () => {
+							await this.createAndOpenDatabase(abstractFile.path)
+						})
+				})
 			})
 		)
 


### PR DESCRIPTION
## Summary
- Right-click a folder in the file explorer to create a Notion Bases database in that folder
- The menu item is hidden when the folder already hosts a database, so it never conflicts with the existing command
- Added a new locale key `ctx_create_database` across all 7 locales

## Test plan
- [ ] Right-click an empty folder → "Create database here" appears → click → database opens
- [ ] Right-click a folder that already has `_database.md` → item does not appear
- [ ] Right-click a file (not folder) → item does not appear
- [ ] Verify label translates correctly in pt-BR

Closes #19