### PR TITLE
feat: live placeholders in note bodies

### DIFF
--- a/src/format-cell-value.ts
+++ b/src/format-cell-value.ts
@@ -1,0 +1,117 @@
+import { ColumnSchema, NumberFormat, SelectOption } from './types'
+
+const SELECT_COLORS = [
+	'#e0e7ff', '#fce7f3', '#fef3c7', '#dcfce7', '#dbeafe', '#e9d5ff',
+	'#fed7aa', '#fecaca', '#d1fae5', '#e0f2fe', '#fae8ff', '#fef9c3',
+	'#ffd6d6', '#d6f0f0', '#f0d6f0', '#f0f0d6',
+]
+
+export function getOptionColor(options: SelectOption[], value: string): string {
+	const opt = options.find(o => o.value === value)
+	if (opt?.color) return opt.color
+	const idx = options.findIndex(o => o.value === value)
+	return SELECT_COLORS[idx % SELECT_COLORS.length] ?? '#e8e8e8'
+}
+
+export function getContrastTextColor(hex: string): string {
+	const c = hex.replace('#', '')
+	const r = parseInt(c.substring(0, 2), 16)
+	const g = parseInt(c.substring(2, 4), 16)
+	const b = parseInt(c.substring(4, 6), 16)
+	const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+	return luminance > 0.5 ? 'rgba(0,0,0,0.75)' : 'rgba(255,255,255,0.9)'
+}
+
+function formatNumber(value: number, fmt: NumberFormat | undefined): string {
+	if (!fmt) return String(value)
+	const opts: Intl.NumberFormatOptions = {
+		minimumFractionDigits: fmt.decimals,
+		maximumFractionDigits: fmt.decimals,
+		useGrouping: fmt.thousandsSeparator,
+	}
+	let result = new Intl.NumberFormat('pt-BR', opts).format(value)
+	if (fmt.prefix) result = `${fmt.prefix} ${result}`
+	if (fmt.suffix) result = `${result} ${fmt.suffix}`
+	return result
+}
+
+function getMoment(): ((d?: Date | string) => { format: (fmt: string) => string }) | null {
+	return (window as unknown as { moment?: (d?: Date | string) => { format: (fmt: string) => string } }).moment ?? null
+}
+
+function toStr(v: unknown): string {
+	if (v == null) return ''
+	if (typeof v === 'string') return v
+	if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+	if (typeof v === 'bigint') return v.toString()
+	try { return JSON.stringify(v) } catch { return '' }
+}
+
+/** Plain text representation of a cell value, honoring the column's type and format. */
+export function formatCellValueText(value: unknown, col: ColumnSchema | undefined, formatHint?: string): string {
+	if (value == null || value === '') return ''
+
+	if (!col) {
+		if (Array.isArray(value)) return value.map(toStr).join(', ')
+		return toStr(value)
+	}
+
+	switch (col.type) {
+		case 'number': {
+			const n = typeof value === 'number' ? value : Number(toStr(value))
+			if (Number.isNaN(n)) return toStr(value)
+			return formatNumber(n, col.numberFormat)
+		}
+		case 'date': {
+			const moment = getMoment()
+			const raw = toStr(value)
+			if (!moment) return raw
+			const fmt = formatHint || 'YYYY-MM-DD'
+			try { return moment(raw).format(fmt) } catch { return raw }
+		}
+		case 'checkbox':
+			return value ? '✓' : '✗'
+		case 'multiselect':
+		case 'relation':
+			if (Array.isArray(value)) return value.map(toStr).join(', ')
+			return toStr(value)
+		default:
+			if (Array.isArray(value)) return value.map(toStr).join(', ')
+			return toStr(value)
+	}
+}
+
+function makePill(text: string, color: string): HTMLSpanElement {
+	const span = document.createElement('span')
+	span.className = 'nb-placeholder-pill'
+	span.textContent = text
+	span.style.background = color
+	span.style.color = getContrastTextColor(color)
+	return span
+}
+
+/**
+ * Render a cell value as DOM nodes, honoring column type. For select/status the value is wrapped
+ * in a colored pill; for multiselect, each option becomes its own pill separated by spaces.
+ * For everything else a single text node is returned.
+ */
+export function formatCellValueNodes(value: unknown, col: ColumnSchema | undefined, formatHint?: string): Node[] {
+	if (value == null || value === '') return [document.createTextNode('')]
+
+	if (col?.type === 'select' || col?.type === 'status') {
+		const text = toStr(value)
+		return [makePill(text, getOptionColor(col.options ?? [], text))]
+	}
+
+	if (col?.type === 'multiselect' && Array.isArray(value)) {
+		const nodes: Node[] = []
+		value.forEach((v, i) => {
+			const text = toStr(v)
+			if (i > 0) nodes.push(document.createTextNode(' '))
+			nodes.push(makePill(text, getOptionColor(col.options ?? [], text)))
+		})
+		return nodes
+	}
+
+	return [document.createTextNode(formatCellValueText(value, col, formatHint))]
+}

--- a/src/live-placeholders.ts
+++ b/src/live-placeholders.ts
@@ -1,0 +1,116 @@
+import { App, MarkdownPostProcessorContext, TFile } from 'obsidian'
+import { DatabaseManager } from './database-manager'
+import { ColumnSchema } from './types'
+import { formatCellValueNodes } from './format-cell-value'
+
+const PLACEHOLDER_RE = /\{\{([a-zA-Z0-9_-]+)(?::([^}]+))?\}\}/g
+
+const SKIP_TAGS = new Set(['CODE', 'PRE', 'SCRIPT', 'STYLE', 'KBD'])
+
+function getMoment(): ((d?: Date | string) => { format: (fmt: string) => string }) | null {
+	return (window as unknown as { moment?: (d?: Date | string) => { format: (fmt: string) => string } }).moment ?? null
+}
+
+function resolveBuiltin(id: string, formatHint: string | undefined, file: TFile): string | null {
+	const moment = getMoment()
+	const now = new Date()
+	switch (id) {
+		case 'title': return file.basename
+		case 'folder': return file.parent?.path ?? ''
+		case 'date': return moment ? moment(now).format(formatHint || 'YYYY-MM-DD') : now.toISOString().slice(0, 10)
+		case 'time': return moment ? moment(now).format(formatHint || 'HH:mm') : now.toTimeString().slice(0, 5)
+		default: return null
+	}
+}
+
+function resolvePlaceholder(
+	id: string,
+	formatHint: string | undefined,
+	schema: ColumnSchema[],
+	frontmatter: Record<string, unknown>,
+	file: TFile,
+): Node[] | null {
+	const builtin = resolveBuiltin(id, formatHint, file)
+	if (builtin !== null) return [document.createTextNode(builtin)]
+
+	const col = schema.find(c => c.id === id)
+	const value = frontmatter[id]
+	if (value === undefined) return null
+
+	return formatCellValueNodes(value, col, formatHint)
+}
+
+function processTextNode(
+	textNode: Text,
+	schema: ColumnSchema[],
+	frontmatter: Record<string, unknown>,
+	file: TFile,
+): void {
+	const text = textNode.nodeValue ?? ''
+	if (!text.includes('{{')) return
+
+	let match: RegExpExecArray | null
+	let lastIdx = 0
+	const parts: Node[] = []
+	let matched = false
+
+	PLACEHOLDER_RE.lastIndex = 0
+	while ((match = PLACEHOLDER_RE.exec(text)) !== null) {
+		const replacement = resolvePlaceholder(match[1], match[2], schema, frontmatter, file)
+		if (replacement === null) continue
+
+		matched = true
+		if (match.index > lastIdx) parts.push(document.createTextNode(text.slice(lastIdx, match.index)))
+		parts.push(...replacement)
+		lastIdx = match.index + match[0].length
+	}
+
+	if (!matched) return
+	if (lastIdx < text.length) parts.push(document.createTextNode(text.slice(lastIdx)))
+
+	const parent = textNode.parentNode
+	if (!parent) return
+	for (const part of parts) parent.insertBefore(part, textNode)
+	parent.removeChild(textNode)
+}
+
+function walkTextNodes(
+	root: Node,
+	schema: ColumnSchema[],
+	frontmatter: Record<string, unknown>,
+	file: TFile,
+): void {
+	const nodes: Text[] = []
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+		acceptNode: (node) => {
+			let parent = node.parentElement
+			while (parent) {
+				if (SKIP_TAGS.has(parent.tagName)) return NodeFilter.FILTER_REJECT
+				if (parent.classList.contains('nb-database-embed')) return NodeFilter.FILTER_REJECT
+				parent = parent.parentElement
+			}
+			return (node.nodeValue && node.nodeValue.includes('{{')) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+		},
+	})
+	let n = walker.nextNode()
+	while (n) { nodes.push(n as Text); n = walker.nextNode() }
+	for (const node of nodes) processTextNode(node, schema, frontmatter, file)
+}
+
+export function createLivePlaceholderProcessor(app: App, manager: DatabaseManager) {
+	return (el: HTMLElement, ctx: MarkdownPostProcessorContext): void => {
+		const file = app.vault.getFileByPath(ctx.sourcePath)
+		if (!file) return
+		// Skip the database file itself — its body shouldn't be substituted.
+		if (manager.isDatabaseFile(file)) return
+
+		const fm = app.metadataCache.getFileCache(file)?.frontmatter as Record<string, unknown> | undefined
+		const frontmatter = fm ?? {}
+
+		const folderPath = file.parent?.path ?? ''
+		const dbFile = manager.getDatabaseFileInFolder(folderPath)
+		const schema: ColumnSchema[] = dbFile ? manager.readConfig(dbFile).schema : []
+
+		walkTextNodes(el, schema, frontmatter, file)
+	}
+}

--- a/src/live-placeholders.ts
+++ b/src/live-placeholders.ts
@@ -1,10 +1,9 @@
-import { App, MarkdownPostProcessorContext, TFile } from 'obsidian'
+import { App, MarkdownPostProcessorContext, MarkdownRenderChild, TFile } from 'obsidian'
 import { DatabaseManager } from './database-manager'
 import { ColumnSchema } from './types'
 import { formatCellValueNodes } from './format-cell-value'
 
 const PLACEHOLDER_RE = /\{\{([a-zA-Z0-9_-]+)(?::([^}]+))?\}\}/g
-
 const SKIP_TAGS = new Set(['CODE', 'PRE', 'SCRIPT', 'STYLE', 'KBD'])
 
 function getMoment(): ((d?: Date | string) => { format: (fmt: string) => string }) | null {
@@ -23,7 +22,7 @@ function resolveBuiltin(id: string, formatHint: string | undefined, file: TFile)
 	}
 }
 
-function resolvePlaceholder(
+function resolveNodes(
 	id: string,
 	formatHint: string | undefined,
 	schema: ColumnSchema[],
@@ -32,54 +31,49 @@ function resolvePlaceholder(
 ): Node[] | null {
 	const builtin = resolveBuiltin(id, formatHint, file)
 	if (builtin !== null) return [document.createTextNode(builtin)]
-
 	const col = schema.find(c => c.id === id)
 	const value = frontmatter[id]
 	if (value === undefined) return null
-
 	return formatCellValueNodes(value, col, formatHint)
 }
 
-function processTextNode(
-	textNode: Text,
-	schema: ColumnSchema[],
-	frontmatter: Record<string, unknown>,
-	file: TFile,
-): void {
-	const text = textNode.nodeValue ?? ''
-	if (!text.includes('{{')) return
+function makePlaceholderSpan(id: string, formatHint: string | undefined): HTMLSpanElement {
+	const span = document.createElement('span')
+	span.className = 'nb-placeholder'
+	span.dataset.token = id
+	if (formatHint) span.dataset.format = formatHint
+	span.textContent = formatHint ? `{{${id}:${formatHint}}}` : `{{${id}}}`
+	return span
+}
 
-	let match: RegExpExecArray | null
-	let lastIdx = 0
-	const parts: Node[] = []
-	let matched = false
+function wrapTextNode(textNode: Text): boolean {
+	const text = textNode.nodeValue ?? ''
+	if (!text.includes('{{')) return false
 
 	PLACEHOLDER_RE.lastIndex = 0
-	while ((match = PLACEHOLDER_RE.exec(text)) !== null) {
-		const replacement = resolvePlaceholder(match[1], match[2], schema, frontmatter, file)
-		if (replacement === null) continue
+	const parts: Node[] = []
+	let lastIdx = 0
+	let match: RegExpExecArray | null
+	let matched = false
 
+	while ((match = PLACEHOLDER_RE.exec(text)) !== null) {
 		matched = true
 		if (match.index > lastIdx) parts.push(document.createTextNode(text.slice(lastIdx, match.index)))
-		parts.push(...replacement)
+		parts.push(makePlaceholderSpan(match[1], match[2]))
 		lastIdx = match.index + match[0].length
 	}
 
-	if (!matched) return
+	if (!matched) return false
 	if (lastIdx < text.length) parts.push(document.createTextNode(text.slice(lastIdx)))
 
 	const parent = textNode.parentNode
-	if (!parent) return
+	if (!parent) return false
 	for (const part of parts) parent.insertBefore(part, textNode)
 	parent.removeChild(textNode)
+	return true
 }
 
-function walkTextNodes(
-	root: Node,
-	schema: ColumnSchema[],
-	frontmatter: Record<string, unknown>,
-	file: TFile,
-): void {
+function wrapAllPlaceholders(root: HTMLElement): boolean {
 	const nodes: Text[] = []
 	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
 		acceptNode: (node) => {
@@ -94,23 +88,66 @@ function walkTextNodes(
 	})
 	let n = walker.nextNode()
 	while (n) { nodes.push(n as Text); n = walker.nextNode() }
-	for (const node of nodes) processTextNode(node, schema, frontmatter, file)
+	let any = false
+	for (const node of nodes) { if (wrapTextNode(node)) any = true }
+	return any
+}
+
+class PlaceholderChild extends MarkdownRenderChild {
+	private listener?: (file: TFile) => void
+
+	constructor(
+		containerEl: HTMLElement,
+		private app: App,
+		private manager: DatabaseManager,
+		private file: TFile,
+	) {
+		super(containerEl)
+	}
+
+	onload(): void {
+		this.render()
+		this.listener = (file: TFile) => {
+			if (file.path === this.file.path) this.render()
+		}
+		this.app.metadataCache.on('changed', this.listener)
+	}
+
+	onunload(): void {
+		if (this.listener) this.app.metadataCache.off('changed', this.listener)
+	}
+
+	private render(): void {
+		const fm = this.app.metadataCache.getFileCache(this.file)?.frontmatter as Record<string, unknown> | undefined
+		const frontmatter = fm ?? {}
+		const folderPath = this.file.parent?.path ?? ''
+		const dbFile = this.manager.getDatabaseFileInFolder(folderPath)
+		const schema: ColumnSchema[] = dbFile ? this.manager.readConfig(dbFile).schema : []
+
+		const spans = this.containerEl.querySelectorAll<HTMLSpanElement>('span.nb-placeholder')
+		spans.forEach(span => {
+			const id = span.dataset.token ?? ''
+			const fmt = span.dataset.format || undefined
+			if (!id) return
+			const nodes = resolveNodes(id, fmt, schema, frontmatter, this.file)
+			if (nodes === null) {
+				span.textContent = fmt ? `{{${id}:${fmt}}}` : `{{${id}}}`
+				return
+			}
+			span.replaceChildren(...nodes)
+		})
+	}
 }
 
 export function createLivePlaceholderProcessor(app: App, manager: DatabaseManager) {
 	return (el: HTMLElement, ctx: MarkdownPostProcessorContext): void => {
 		const file = app.vault.getFileByPath(ctx.sourcePath)
 		if (!file) return
-		// Skip the database file itself — its body shouldn't be substituted.
 		if (manager.isDatabaseFile(file)) return
 
-		const fm = app.metadataCache.getFileCache(file)?.frontmatter as Record<string, unknown> | undefined
-		const frontmatter = fm ?? {}
+		const anyWrapped = wrapAllPlaceholders(el)
+		if (!anyWrapped) return
 
-		const folderPath = file.parent?.path ?? ''
-		const dbFile = manager.getDatabaseFileInFolder(folderPath)
-		const schema: ColumnSchema[] = dbFile ? manager.readConfig(dbFile).schema : []
-
-		walkTextNodes(el, schema, frontmatter, file)
+		ctx.addChild(new PlaceholderChild(el, app, manager, file))
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { DEFAULT_SETTINGS, NotionBasesSettings, NotionBasesSettingTab } from './
 import { DatabasePickerModal } from './database-picker-modal'
 import { QuickAddModal } from './quick-add-modal'
 import { registerDatabaseEmbed } from './database-embed'
+import { createLivePlaceholderProcessor } from './live-placeholders'
 
 export default class NotionBasesPlugin extends Plugin {
 	settings: NotionBasesSettings
@@ -99,6 +100,9 @@ export default class NotionBasesPlugin extends Plugin {
 
 		// Embed de database em notas via ```nb-database
 		registerDatabaseEmbed(this)
+
+		// Live placeholders — substitui {{columnId}} no corpo das notas em tempo de renderização
+		this.registerMarkdownPostProcessor(createLivePlaceholderProcessor(this.app, this.manager))
 
 		// Settings tab
 		this.addSettingTab(new NotionBasesSettingTab(this.app, this))

--- a/styles.css
+++ b/styles.css
@@ -5503,3 +5503,14 @@ body.nb-tl-resizing * {
 .nb-cf-btn--cancel:hover {
 	background: var(--background-modifier-border);
 }
+
+/* Live placeholder pills (rendered by the markdown post-processor) */
+.nb-placeholder-pill {
+	display: inline-block;
+	padding: 1px 8px;
+	border-radius: 10px;
+	font-size: 0.85em;
+	line-height: 1.4;
+	white-space: nowrap;
+	vertical-align: baseline;
+}

--- a/tests/format-cell-value.test.ts
+++ b/tests/format-cell-value.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { formatCellValueText } from '../src/format-cell-value'
+import { ColumnSchema } from '../src/types'
+
+function col(type: ColumnSchema['type'], extra: Partial<ColumnSchema> = {}): ColumnSchema {
+	return { id: 'x', name: 'x', type, visible: true, ...extra }
+}
+
+describe('formatCellValueText', () => {
+	it('returns empty string for null/undefined/empty', () => {
+		expect(formatCellValueText(null, col('text'))).toBe('')
+		expect(formatCellValueText(undefined, col('text'))).toBe('')
+		expect(formatCellValueText('', col('text'))).toBe('')
+	})
+
+	it('handles text and title as plain string', () => {
+		expect(formatCellValueText('hello', col('text'))).toBe('hello')
+		expect(formatCellValueText('My note', col('title'))).toBe('My note')
+	})
+
+	it('formats numbers with NumberFormat', () => {
+		const c = col('number', { numberFormat: { decimals: 2, thousandsSeparator: true, prefix: 'R$' } })
+		expect(formatCellValueText(1234.5, c)).toContain('R$')
+		expect(formatCellValueText(1234.5, c)).toContain(',50')
+	})
+
+	it('returns raw number when no format is set', () => {
+		expect(formatCellValueText(42, col('number'))).toBe('42')
+	})
+
+	it('joins multiselect arrays with comma', () => {
+		expect(formatCellValueText(['a', 'b', 'c'], col('multiselect'))).toBe('a, b, c')
+	})
+
+	it('joins relation arrays with comma', () => {
+		expect(formatCellValueText(['alpha', 'beta'], col('relation'))).toBe('alpha, beta')
+	})
+
+	it('renders checkbox as ✓ or ✗', () => {
+		expect(formatCellValueText(true, col('checkbox'))).toBe('✓')
+		expect(formatCellValueText(false, col('checkbox'))).toBe('✗')
+	})
+
+	it('falls back to String for select/status', () => {
+		expect(formatCellValueText('Done', col('select'))).toBe('Done')
+		expect(formatCellValueText('In progress', col('status'))).toBe('In progress')
+	})
+
+	it('handles missing column by joining arrays', () => {
+		expect(formatCellValueText(['a', 'b'], undefined)).toBe('a, b')
+		expect(formatCellValueText('plain', undefined)).toBe('plain')
+	})
+
+	it('returns empty string for objects rather than [object Object]', () => {
+		// toStr uses JSON.stringify for unknown types
+		expect(formatCellValueText({ foo: 'bar' }, col('text'))).toBe('{"foo":"bar"}')
+	})
+})


### PR DESCRIPTION
## Summary
- New markdown post-processor substitutes `{{columnId}}` tokens in rendered note bodies with the current frontmatter value. The file on disk is never rewritten — edits to a cell update the reading view immediately.
- Built-in tokens (`{{title}}`, `{{folder}}`, `{{date[:fmt]}}`, `{{time[:fmt]}}`) now render live too, so they stay accurate forever instead of being frozen at creation.
- Column tokens use the governing database schema for type-aware formatting (numbers with `NumberFormat`, dates with moment, multiselect joined, checkbox as ✓/✗).
- `select` / `status` values render as colored pills matching the table view.

## Tradeoff
Source/edit mode still shows the raw `{{columnId}}` literal. This is intentional — keeping the placeholder in the file means user edits to the body are never clobbered and there are no race conditions between frontmatter writes and body rewrites.

## Test plan
- [ ] Create a template with `Status: {{status}}` and `Due: {{due:DD/MM/YYYY}}`
- [ ] Create a row → open in reading view → values appear substituted
- [ ] Edit the status cell in the table → reading view reflects new value immediately
- [ ] Source mode shows the raw `{{status}}` token (expected)
- [ ] `{{title}}`, `{{folder}}`, `{{date}}`, `{{time}}` render correctly
- [ ] Placeholders inside code blocks / inline code are NOT substituted
- [ ] Notes outside a database folder: only built-ins resolve, column tokens fall back to raw frontmatter

Closes #18