### PR TITLE
feat: auto-arrange row files into subfolders by property values

### DIFF
--- a/src/components/DatabaseRoot.tsx
+++ b/src/components/DatabaseRoot.tsx
@@ -36,6 +36,16 @@ export function DatabaseRoot({
 
 	// ── Shared config (used for direct mode tabs + free embed initialization) ─
 	const [config, setConfig] = useState<DatabaseConfig>(DEFAULT_DATABASE_CONFIG)
+	const pendingSelfWrites = useRef(0)
+	const writeConfigAndTrack = useCallback(async (cfg: DatabaseConfig) => {
+		if (!dbFile) return
+		pendingSelfWrites.current++
+		try {
+			await manager.writeConfig(dbFile, cfg)
+		} finally {
+			setTimeout(() => { pendingSelfWrites.current = Math.max(0, pendingSelfWrites.current - 1) }, 150)
+		}
+	}, [dbFile, manager])
 
 	// ── Direct mode state ─────────────────────────────────────────────────────
 	const [activeViewId, setActiveViewId] = useState('')
@@ -91,7 +101,9 @@ export function DatabaseRoot({
 	useEffect(() => {
 		if (!dbFile || !isDirectMode) return
 		const onChange = (file: TFile) => {
-			if (file === dbFile) setConfig(manager.readConfig(dbFile))
+			if (file !== dbFile) return
+			if (pendingSelfWrites.current > 0) return
+			setConfig(manager.readConfig(dbFile))
 		}
 		app.metadataCache.on('changed', onChange)
 		return () => app.metadataCache.off('changed', onChange)
@@ -147,7 +159,7 @@ export function DatabaseRoot({
 		const newViews = reorderViews(config.views, dragViewId, toId)
 		const newConfig = { ...config, views: newViews }
 		setConfig(newConfig); setDragViewId(null)
-		await manager.writeConfig(dbFile, newConfig)
+		await writeConfigAndTrack(newConfig)
 	}
 
 	const handleEmbedTabDrop = async (toId: string) => {
@@ -299,8 +311,8 @@ export function DatabaseRoot({
 		const newViews = config.views.map(v => v.id === updatedView.id ? updatedView : v)
 		const newConfig = { ...config, views: newViews }
 		setConfig(newConfig)
-		await manager.writeConfig(dbFile, newConfig)
-	}, [config, dbFile, manager])
+		await writeConfigAndTrack(newConfig)
+	}, [config, dbFile, writeConfigAndTrack])
 
 	const addView = useCallback(async (type: ViewConfig['type']) => {
 		if (!dbFile) return
@@ -323,8 +335,8 @@ export function DatabaseRoot({
 		setConfig(newConfig)
 		setActiveViewId(newView.id)
 		setAddMenuOpen(false)
-		await manager.writeConfig(dbFile, newConfig)
-	}, [config, dbFile, manager])
+		await writeConfigAndTrack(newConfig)
+	}, [config, dbFile, writeConfigAndTrack])
 
 	const removeView = useCallback(async (viewId: string) => {
 		if (!dbFile || config.views.length <= 1) return
@@ -332,8 +344,8 @@ export function DatabaseRoot({
 		const newConfig = { ...config, views: newViews }
 		setConfig(newConfig)
 		if (activeViewId === viewId) setActiveViewId(newViews[0].id)
-		await manager.writeConfig(dbFile, newConfig)
-	}, [config, dbFile, manager, activeViewId])
+		await writeConfigAndTrack(newConfig)
+	}, [config, dbFile, writeConfigAndTrack, activeViewId])
 
 	const activeView = config.views.find(v => v.id === activeViewId) ?? config.views[0] ?? DEFAULT_VIEW
 	const isSingleTableView = config.views.length === 1 && activeView.type === 'table'
@@ -342,7 +354,7 @@ export function DatabaseRoot({
 		if (!dbFile) return
 		const newConfig = { ...config, views: updatedViews }
 		setConfig(newConfig)
-		await manager.writeConfig(dbFile, newConfig)
+		await writeConfigAndTrack(newConfig)
 	}
 
 	return (
@@ -417,8 +429,8 @@ export function DatabaseRoot({
 						new DatabaseSettingsModal(app, config, async (updated) => {
 							const newConfig = { ...config, ...updated }
 							setConfig(newConfig)
-							await manager.writeConfig(dbFile, newConfig)
-						}).open()
+							await writeConfigAndTrack(newConfig)
+						}, manager, dbFile).open()
 					}}
 				>
 					⚙

--- a/src/database-manager.ts
+++ b/src/database-manager.ts
@@ -6,6 +6,7 @@ import {
 	DatabaseConfig,
 	DEFAULT_DATABASE_CONFIG,
 	DEFAULT_VIEW,
+	FolderArrangementConfig,
 	InlineFieldMeta,
 	NoteRow,
 	RollupFunction,
@@ -15,6 +16,10 @@ import { parseInlineFields, frontmatterLineCount } from './inline-fields'
 import { TemplatePickerModal } from './template-picker-modal'
 
 export const DATABASE_MARKER = 'notion-bases'
+
+export function sanitizeSegment(s: string): string {
+	return s.replace(/[/\\:*?"<>|]/g, '').replace(/\s+/g, ' ').trim()
+}
 
 export class DatabaseManager {
 	readInlineFields = false
@@ -53,11 +58,20 @@ export class DatabaseManager {
 			!(col.options?.some(o => o.value === '[object Object]'))
 		)
 
+		const rawArrangement = fm['folderArrangement']
+		let folderArrangement: FolderArrangementConfig | undefined
+		if (rawArrangement && typeof rawArrangement === 'object' && !Array.isArray(rawArrangement)) {
+			const r = rawArrangement as Record<string, unknown>
+			const ids = Array.isArray(r['propertyIds']) ? (r['propertyIds'] as unknown[]).filter((v): v is string => typeof v === 'string') : []
+			folderArrangement = { enabled: r['enabled'] === true, propertyIds: ids }
+		}
+
 		return {
 			schema,
 			views: Array.isArray(fm['views']) && (fm['views'] as unknown[]).length > 0 ? fm['views'] as ViewConfig[] : [DEFAULT_VIEW],
 			templatePath: typeof fm['templatePath'] === 'string' && fm['templatePath'] ? fm['templatePath'] : undefined,
 			askTemplateOnCreate: fm['askTemplateOnCreate'] === true,
+			folderArrangement,
 		}
 	}
 
@@ -70,6 +84,14 @@ export class DatabaseManager {
 			else delete fm['templatePath']
 			if (config.askTemplateOnCreate) fm['askTemplateOnCreate'] = true
 			else delete fm['askTemplateOnCreate']
+			if (config.folderArrangement && config.folderArrangement.propertyIds.length > 0) {
+				fm['folderArrangement'] = {
+					enabled: !!config.folderArrangement.enabled,
+					propertyIds: config.folderArrangement.propertyIds,
+				}
+			} else {
+				delete fm['folderArrangement']
+			}
 		})
 	}
 
@@ -403,6 +425,117 @@ export class DatabaseManager {
 		if (body.trim()) {
 			const current = await this.app.vault.read(targetFile)
 			await this.app.vault.modify(targetFile, current + substitute(body))
+		}
+	}
+
+	// ── Folder arrangement ─────────────────────────────────────────────────
+
+	private folderArrangementInProgress = new Set<string>()
+
+	/** Returns the database file that "governs" a row file (db located in any ancestor folder). */
+	findGoverningDatabase(file: TFile): TFile | null {
+		let folder = file.parent
+		while (folder) {
+			const db = this.getDatabaseFileInFolder(folder.path)
+			if (db && db.path !== file.path) return db
+			folder = folder.parent
+		}
+		return null
+	}
+
+	/**
+	 * Compute the path a row file should live at given the database's folderArrangement config.
+	 * Returns null if the file is already at the right place, the db file itself, or arrangement is off.
+	 */
+	computeArrangedPath(file: TFile, dbFile: TFile, config: DatabaseConfig): string | null {
+		const arr = config.folderArrangement
+		if (!arr || !arr.enabled || arr.propertyIds.length === 0) return null
+		if (file.path === dbFile.path) return null
+
+		const fm = this.app.metadataCache.getFileCache(file)?.frontmatter as Record<string, unknown> | undefined
+		const segments: string[] = []
+		for (const id of arr.propertyIds) {
+			const v = fm?.[id]
+			if (v == null || v === '') break
+			const raw = Array.isArray(v) ? (v[0] as unknown) : v
+			if (raw == null || raw === '') break
+			let str: string
+			if (typeof raw === 'string') str = raw
+			else if (typeof raw === 'number' || typeof raw === 'boolean' || typeof raw === 'bigint') str = String(raw)
+			else continue
+			const seg = sanitizeSegment(str)
+			if (!seg) break
+			segments.push(seg)
+		}
+
+		const dbFolder = dbFile.parent?.path ?? ''
+		const targetFolder = [dbFolder, ...segments].filter(Boolean).join('/')
+		const target = normalizePath(`${targetFolder ? `${targetFolder}/` : ''}${file.basename}.md`)
+		if (target === file.path) return null
+		return target
+	}
+
+	isArrangementInProgress(path: string): boolean {
+		return this.folderArrangementInProgress.has(path)
+	}
+
+	/** Move the file to its arranged location if needed. Returns true if a move happened. */
+	async applyArrangement(file: TFile, dbFile: TFile, config: DatabaseConfig): Promise<boolean> {
+		const target = this.computeArrangedPath(file, dbFile, config)
+		if (!target) return false
+		if (this.folderArrangementInProgress.has(file.path)) return false
+
+		const targetFolder = target.slice(0, target.lastIndexOf('/'))
+		if (targetFolder) await this.ensureFolder(targetFolder)
+
+		// Skip if a sibling with the same basename already exists at target
+		if (this.app.vault.getFileByPath(target)) return false
+
+		this.folderArrangementInProgress.add(file.path)
+		this.folderArrangementInProgress.add(target)
+		try {
+			await this.app.fileManager.renameFile(file, target)
+		} finally {
+			setTimeout(() => {
+				this.folderArrangementInProgress.delete(file.path)
+				this.folderArrangementInProgress.delete(target)
+			}, 500)
+		}
+		return true
+	}
+
+	/** Apply arrangement to every row in the database. Returns the list of moves performed. */
+	async applyArrangementToAll(dbFile: TFile, config: DatabaseConfig): Promise<{ from: string; to: string }[]> {
+		const moves: { from: string; to: string }[] = []
+		const notes = this.getNotesInDatabase(dbFile, true)
+		for (const note of notes) {
+			const target = this.computeArrangedPath(note, dbFile, config)
+			if (!target) continue
+			const from = note.path
+			const moved = await this.applyArrangement(note, dbFile, config)
+			if (moved) moves.push({ from, to: target })
+		}
+		return moves
+	}
+
+	/** Compute (without applying) the moves that would happen for every row. */
+	previewArrangement(dbFile: TFile, config: DatabaseConfig): { file: TFile; from: string; to: string | null }[] {
+		const notes = this.getNotesInDatabase(dbFile, true)
+		return notes.map(note => ({
+			file: note,
+			from: note.path,
+			to: this.computeArrangedPath(note, dbFile, config),
+		}))
+	}
+
+	private async ensureFolder(path: string): Promise<void> {
+		const parts = path.split('/').filter(Boolean)
+		let cur = ''
+		for (const p of parts) {
+			cur = cur ? `${cur}/${p}` : p
+			if (!this.app.vault.getFolderByPath(cur)) {
+				try { await this.app.vault.createFolder(cur) } catch { /* race: another caller created it */ }
+			}
 		}
 	}
 

--- a/src/database-settings-modal.ts
+++ b/src/database-settings-modal.ts
@@ -1,20 +1,36 @@
-import { App, Modal, Setting } from 'obsidian'
-import { DatabaseConfig } from './types'
+import { App, Modal, Setting, TFile } from 'obsidian'
+import { ColumnType, DatabaseConfig, FolderArrangementConfig } from './types'
 import { TemplatePickerModal } from './template-picker-modal'
+import { DatabaseManager } from './database-manager'
+import { FolderArrangementPreviewModal } from './folder-arrangement-preview-modal'
 import { t } from './i18n'
+
+const ARRANGEMENT_SUPPORTED_TYPES: ColumnType[] = ['text', 'select', 'status', 'date']
+
+type SettingsUpdate = {
+	templatePath?: string
+	askTemplateOnCreate?: boolean
+	folderArrangement?: FolderArrangementConfig
+}
 
 export class DatabaseSettingsModal extends Modal {
 	private config: DatabaseConfig
-	private onSave: (updated: { templatePath?: string; askTemplateOnCreate?: boolean }) => Promise<void> | void
+	private onSave: (updated: SettingsUpdate) => Promise<void> | void
+	private manager: DatabaseManager | null
+	private dbFile: TFile | null
 
 	constructor(
 		app: App,
 		config: DatabaseConfig,
-		onSave: (updated: { templatePath?: string; askTemplateOnCreate?: boolean }) => Promise<void> | void,
+		onSave: (updated: SettingsUpdate) => Promise<void> | void,
+		manager?: DatabaseManager,
+		dbFile?: TFile | null,
 	) {
 		super(app)
 		this.config = config
 		this.onSave = onSave
+		this.manager = manager ?? null
+		this.dbFile = dbFile ?? null
 	}
 
 	onOpen(): void {
@@ -52,7 +68,6 @@ export class DatabaseSettingsModal extends Modal {
 					this.config = { ...this.config, templatePath: undefined }
 					renderPath()
 					await this.onSave({ templatePath: undefined })
-					// Re-render modal so the clear button disappears
 					this.onOpen()
 				}))
 		}
@@ -67,6 +82,120 @@ export class DatabaseSettingsModal extends Modal {
 					this.config = { ...this.config, askTemplateOnCreate: v }
 					await this.onSave({ askTemplateOnCreate: v })
 				}))
+
+		// ── Folder arrangement ────────────────────────────────────────────
+		this.renderArrangementSection(contentEl)
+	}
+
+	private renderArrangementSection(contentEl: HTMLElement): void {
+		const section = contentEl.createDiv({ cls: 'nb-db-settings-arrangement' })
+		section.createEl('h3', { text: t('arr_settings_title') })
+		section.createEl('p', { text: t('arr_settings_desc'), cls: 'nb-db-settings-arrangement-desc' })
+
+		const current: FolderArrangementConfig = this.config.folderArrangement
+			? { enabled: !!this.config.folderArrangement.enabled, propertyIds: [...this.config.folderArrangement.propertyIds] }
+			: { enabled: false, propertyIds: [] }
+
+		const persist = async () => {
+			this.config = { ...this.config, folderArrangement: current }
+			await this.onSave({ folderArrangement: current })
+		}
+
+		new Setting(section)
+			.setName(t('arr_settings_enabled_name'))
+			.setDesc(t('arr_settings_enabled_desc'))
+			.addToggle(tg => tg
+				.setValue(current.enabled)
+				.onChange(async (v) => {
+					current.enabled = v
+					await persist()
+				}))
+
+		const candidates = this.config.schema.filter(c =>
+			ARRANGEMENT_SUPPORTED_TYPES.includes(c.type) && !current.propertyIds.includes(c.id)
+		)
+
+		const listEl = section.createDiv({ cls: 'nb-arr-property-list' })
+		const renderList = () => {
+			listEl.empty()
+			if (current.propertyIds.length === 0) {
+				listEl.createEl('p', { text: t('arr_settings_no_props'), cls: 'nb-arr-empty' })
+				return
+			}
+			current.propertyIds.forEach((id, idx) => {
+				const col = this.config.schema.find(c => c.id === id)
+				const row = listEl.createDiv({ cls: 'nb-arr-property-row' })
+				row.createSpan({ cls: 'nb-arr-property-index', text: String(idx + 1) })
+				row.createSpan({ cls: 'nb-arr-property-name', text: col?.name ?? id })
+
+				const upBtn = row.createEl('button', { text: '↑', cls: 'nb-arr-btn' })
+				upBtn.disabled = idx === 0
+				upBtn.onclick = async () => {
+					[current.propertyIds[idx - 1], current.propertyIds[idx]] = [current.propertyIds[idx], current.propertyIds[idx - 1]]
+					await persist()
+					renderList()
+				}
+
+				const downBtn = row.createEl('button', { text: '↓', cls: 'nb-arr-btn' })
+				downBtn.disabled = idx === current.propertyIds.length - 1
+				downBtn.onclick = async () => {
+					[current.propertyIds[idx + 1], current.propertyIds[idx]] = [current.propertyIds[idx], current.propertyIds[idx + 1]]
+					await persist()
+					renderList()
+				}
+
+				const rmBtn = row.createEl('button', { text: '×', cls: 'nb-arr-btn nb-arr-btn-remove' })
+				rmBtn.onclick = async () => {
+					current.propertyIds.splice(idx, 1)
+					await persist()
+					renderList()
+					renderAddRow()
+				}
+			})
+		}
+
+		const addRow = section.createDiv({ cls: 'nb-arr-add-row' })
+		const renderAddRow = () => {
+			addRow.empty()
+			const remaining = this.config.schema.filter(c =>
+				ARRANGEMENT_SUPPORTED_TYPES.includes(c.type) && !current.propertyIds.includes(c.id)
+			)
+			if (remaining.length === 0 && candidates.length === 0) {
+				addRow.createEl('p', { text: t('arr_settings_no_candidates'), cls: 'nb-arr-empty' })
+				return
+			}
+			if (remaining.length === 0) return
+
+			const select = addRow.createEl('select', { cls: 'nb-arr-select' })
+			select.createEl('option', { text: t('arr_settings_add_placeholder'), value: '' })
+			for (const c of remaining) {
+				select.createEl('option', { text: c.name, value: c.id })
+			}
+			const addBtn = addRow.createEl('button', { text: t('arr_settings_add_btn'), cls: 'mod-cta nb-arr-add-btn' })
+			addBtn.onclick = async () => {
+				const v = select.value
+				if (!v) return
+				current.propertyIds.push(v)
+				await persist()
+				renderList()
+				renderAddRow()
+			}
+		}
+
+		renderList()
+		renderAddRow()
+
+		// Preview & apply button
+		if (this.manager && this.dbFile) {
+			const previewBtn = section.createEl('button', {
+				text: t('arr_settings_preview_btn'),
+				cls: 'nb-arr-preview-btn',
+			})
+			previewBtn.onclick = () => {
+				if (!this.manager || !this.dbFile) return
+				new FolderArrangementPreviewModal(this.app, this.manager, this.dbFile, { ...this.config, folderArrangement: current }).open()
+			}
+		}
 	}
 
 	onClose(): void {

--- a/src/folder-arrangement-preview-modal.ts
+++ b/src/folder-arrangement-preview-modal.ts
@@ -1,0 +1,55 @@
+import { App, Modal, Notice, TFile } from 'obsidian'
+import { DatabaseConfig } from './types'
+import { DatabaseManager } from './database-manager'
+import { t } from './i18n'
+
+export class FolderArrangementPreviewModal extends Modal {
+	constructor(
+		app: App,
+		private manager: DatabaseManager,
+		private dbFile: TFile,
+		private config: DatabaseConfig,
+	) {
+		super(app)
+	}
+
+	onOpen(): void {
+		const { contentEl } = this
+		contentEl.empty()
+		contentEl.createEl('h2', { text: t('arr_preview_title') })
+
+		const moves = this.manager.previewArrangement(this.dbFile, this.config)
+			.filter(m => m.to !== null)
+
+		if (moves.length === 0) {
+			contentEl.createEl('p', { text: t('arr_preview_empty') })
+		} else {
+			contentEl.createEl('p', { text: t('arr_preview_desc').replace('$count', String(moves.length)) })
+			const list = contentEl.createEl('div', { cls: 'nb-arr-preview-list' })
+			for (const m of moves) {
+				const row = list.createEl('div', { cls: 'nb-arr-preview-row' })
+				row.createSpan({ cls: 'nb-arr-preview-from', text: m.from })
+				row.createSpan({ cls: 'nb-arr-preview-arrow', text: '→' })
+				row.createSpan({ cls: 'nb-arr-preview-to', text: m.to ?? '' })
+			}
+		}
+
+		const buttons = contentEl.createEl('div', { cls: 'nb-arr-preview-actions' })
+		const cancelBtn = buttons.createEl('button', { text: t('arr_preview_cancel') })
+		cancelBtn.onclick = () => this.close()
+
+		const applyBtn = buttons.createEl('button', { text: t('arr_preview_apply'), cls: 'mod-cta' })
+		applyBtn.disabled = moves.length === 0
+		applyBtn.onclick = async () => {
+			applyBtn.disabled = true
+			cancelBtn.disabled = true
+			const applied = await this.manager.applyArrangementToAll(this.dbFile, this.config)
+			new Notice(t('arr_preview_applied').replace('$count', String(applied.length)))
+			this.close()
+		}
+	}
+
+	onClose(): void {
+		this.contentEl.empty()
+	}
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -447,6 +447,23 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	cmd_open_database: 'Datenbank für diesen Ordner öffnen',
 	cmd_create_database: 'Neue Datenbank im aktuellen Ordner erstellen',
 
+	// Folder arrangement
+	arr_settings_title: 'Ordnerorganisation',
+	arr_settings_desc: 'Verschiebt Zeilendateien automatisch in verschachtelte Unterordner basierend auf den Werten der ausgewählten Eigenschaften, in der angegebenen Reihenfolge.',
+	arr_settings_enabled_name: 'Ordnerorganisation aktivieren',
+	arr_settings_enabled_desc: 'Wenn aktiviert, werden Zeilen verschoben, sobald sich eine der ausgewählten Eigenschaften ändert. Standardmäßig deaktiviert.',
+	arr_settings_no_props: 'Keine Eigenschaften ausgewählt. Fügen Sie unten eine hinzu, um die Ordnerhierarchie zu definieren.',
+	arr_settings_no_candidates: 'Keine geeigneten Spalten. Die Ordnerorganisation unterstützt Text-, Auswahl-, Status- und Datumsspalten.',
+	arr_settings_add_placeholder: 'Eigenschaft auswählen...',
+	arr_settings_add_btn: 'Hinzufügen',
+	arr_settings_preview_btn: 'Vorschau und auf bestehende Zeilen anwenden',
+	arr_preview_title: 'Vorschau der Ordnerorganisation',
+	arr_preview_empty: 'Keine Zeilen müssen verschoben werden.',
+	arr_preview_desc: '$count Zeile(n) werden verschoben:',
+	arr_preview_apply: 'Anwenden',
+	arr_preview_cancel: 'Abbrechen',
+	arr_preview_applied: '$count Zeile(n) verschoben.',
+
 	// Quick add
 	cmd_quick_add: 'Zeile schnell zur Datenbank hinzufügen',
 	quick_add_title: 'Schnell hinzufügen',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -445,6 +445,23 @@ const en = {
 	cmd_open_database: 'Open database for this folder',
 	cmd_create_database: 'Create new database in current folder',
 
+	// Folder arrangement
+	arr_settings_title: 'Folder arrangement',
+	arr_settings_desc: 'Automatically move row files into nested subfolders based on the values of the selected properties, in order.',
+	arr_settings_enabled_name: 'Enable folder arrangement',
+	arr_settings_enabled_desc: 'When on, rows are moved as soon as one of the selected properties changes. Off by default.',
+	arr_settings_no_props: 'No properties selected. Add one below to define the folder hierarchy.',
+	arr_settings_no_candidates: 'No eligible columns. Folder arrangement supports text, select, status, and date columns.',
+	arr_settings_add_placeholder: 'Select a property...',
+	arr_settings_add_btn: 'Add',
+	arr_settings_preview_btn: 'Preview & apply to existing rows',
+	arr_preview_title: 'Folder arrangement preview',
+	arr_preview_empty: 'No rows need to be moved.',
+	arr_preview_desc: '$count row(s) will be moved:',
+	arr_preview_apply: 'Apply',
+	arr_preview_cancel: 'Cancel',
+	arr_preview_applied: 'Moved $count row(s).',
+
 	// Quick add
 	cmd_quick_add: 'Quick add row to database',
 	quick_add_title: 'Quick add',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -447,6 +447,23 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	cmd_open_database: 'Abrir base de datos de esta carpeta',
 	cmd_create_database: 'Crear nueva base de datos en la carpeta actual',
 
+	// Folder arrangement
+	arr_settings_title: 'Organización por carpetas',
+	arr_settings_desc: 'Mueve automáticamente los archivos de fila a subcarpetas anidadas según los valores de las propiedades seleccionadas, en orden.',
+	arr_settings_enabled_name: 'Activar organización por carpetas',
+	arr_settings_enabled_desc: 'Cuando está activado, las filas se mueven en cuanto cambia una de las propiedades seleccionadas. Desactivado por defecto.',
+	arr_settings_no_props: 'No hay propiedades seleccionadas. Añade una a continuación para definir la jerarquía de carpetas.',
+	arr_settings_no_candidates: 'No hay columnas elegibles. La organización por carpetas admite columnas de texto, selección, estado y fecha.',
+	arr_settings_add_placeholder: 'Seleccionar una propiedad...',
+	arr_settings_add_btn: 'Añadir',
+	arr_settings_preview_btn: 'Previsualizar y aplicar a filas existentes',
+	arr_preview_title: 'Previsualización de la organización por carpetas',
+	arr_preview_empty: 'No hay filas que mover.',
+	arr_preview_desc: '$count fila(s) serán movidas:',
+	arr_preview_apply: 'Aplicar',
+	arr_preview_cancel: 'Cancelar',
+	arr_preview_applied: '$count fila(s) movida(s).',
+
 	// Quick add
 	cmd_quick_add: 'Añadir fila rápidamente a la base de datos',
 	quick_add_title: 'Añadir rápido',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -447,6 +447,23 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	cmd_open_database: 'Ouvrir la base de données de ce dossier',
 	cmd_create_database: 'Créer une nouvelle base de données dans le dossier actuel',
 
+	// Folder arrangement
+	arr_settings_title: 'Organisation par dossiers',
+	arr_settings_desc: 'Déplace automatiquement les fichiers de ligne dans des sous-dossiers imbriqués selon les valeurs des propriétés sélectionnées, dans l\'ordre.',
+	arr_settings_enabled_name: 'Activer l\'organisation par dossiers',
+	arr_settings_enabled_desc: 'Quand activé, les lignes sont déplacées dès qu\'une des propriétés sélectionnées change. Désactivé par défaut.',
+	arr_settings_no_props: 'Aucune propriété sélectionnée. Ajoutez-en une ci-dessous pour définir la hiérarchie de dossiers.',
+	arr_settings_no_candidates: 'Aucune colonne éligible. L\'organisation par dossiers prend en charge les colonnes de texte, sélection, statut et date.',
+	arr_settings_add_placeholder: 'Sélectionner une propriété...',
+	arr_settings_add_btn: 'Ajouter',
+	arr_settings_preview_btn: 'Aperçu et application aux lignes existantes',
+	arr_preview_title: 'Aperçu de l\'organisation par dossiers',
+	arr_preview_empty: 'Aucune ligne ne doit être déplacée.',
+	arr_preview_desc: '$count ligne(s) seront déplacées :',
+	arr_preview_apply: 'Appliquer',
+	arr_preview_cancel: 'Annuler',
+	arr_preview_applied: '$count ligne(s) déplacée(s).',
+
 	// Quick add
 	cmd_quick_add: 'Ajouter rapidement une ligne à la base de données',
 	quick_add_title: 'Ajout rapide',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -447,6 +447,23 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	cmd_open_database: 'このフォルダーのデータベースを開く',
 	cmd_create_database: '現在のフォルダーに新しいデータベースを作成',
 
+	// Folder arrangement
+	arr_settings_title: 'フォルダー整理',
+	arr_settings_desc: '選択したプロパティの値に基づいて、行ファイルを順番にネストされたサブフォルダーへ自動的に移動します。',
+	arr_settings_enabled_name: 'フォルダー整理を有効にする',
+	arr_settings_enabled_desc: '有効にすると、選択したプロパティのいずれかが変更されるとすぐに行が移動されます。デフォルトはオフです。',
+	arr_settings_no_props: 'プロパティが選択されていません。下に追加してフォルダー階層を定義してください。',
+	arr_settings_no_candidates: '対象となる列がありません。フォルダー整理はテキスト、選択、ステータス、日付列に対応しています。',
+	arr_settings_add_placeholder: 'プロパティを選択...',
+	arr_settings_add_btn: '追加',
+	arr_settings_preview_btn: 'プレビューして既存の行に適用',
+	arr_preview_title: 'フォルダー整理のプレビュー',
+	arr_preview_empty: '移動が必要な行はありません。',
+	arr_preview_desc: '$count 行が移動されます：',
+	arr_preview_apply: '適用',
+	arr_preview_cancel: 'キャンセル',
+	arr_preview_applied: '$count 行を移動しました。',
+
 	// Quick add
 	cmd_quick_add: 'データベースに行をすばやく追加',
 	quick_add_title: 'クイック追加',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -447,6 +447,23 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	cmd_open_database: 'Abrir banco de dados desta pasta',
 	cmd_create_database: 'Criar novo banco de dados na pasta atual',
 
+	// Folder arrangement
+	arr_settings_title: 'Organização por pastas',
+	arr_settings_desc: 'Move automaticamente os arquivos de linha para subpastas aninhadas com base nos valores das propriedades selecionadas, na ordem definida.',
+	arr_settings_enabled_name: 'Ativar organização por pastas',
+	arr_settings_enabled_desc: 'Quando ativado, as linhas são movidas assim que uma das propriedades selecionadas é alterada. Desativado por padrão.',
+	arr_settings_no_props: 'Nenhuma propriedade selecionada. Adicione uma abaixo para definir a hierarquia de pastas.',
+	arr_settings_no_candidates: 'Nenhuma coluna elegível. A organização por pastas suporta colunas de texto, seleção, status e data.',
+	arr_settings_add_placeholder: 'Selecionar uma propriedade...',
+	arr_settings_add_btn: 'Adicionar',
+	arr_settings_preview_btn: 'Pré-visualizar e aplicar às linhas existentes',
+	arr_preview_title: 'Pré-visualização da organização por pastas',
+	arr_preview_empty: 'Nenhuma linha precisa ser movida.',
+	arr_preview_desc: '$count linha(s) será(ão) movida(s):',
+	arr_preview_apply: 'Aplicar',
+	arr_preview_cancel: 'Cancelar',
+	arr_preview_applied: '$count linha(s) movida(s).',
+
 	// Quick add
 	cmd_quick_add: 'Adicionar linha rapidamente ao banco de dados',
 	quick_add_title: 'Adição rápida',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -447,6 +447,23 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	cmd_open_database: '打开此文件夹的数据库',
 	cmd_create_database: '在当前文件夹创建新数据库',
 
+	// Folder arrangement
+	arr_settings_title: '文件夹排列',
+	arr_settings_desc: '根据所选属性的值，按顺序自动将行文件移动到嵌套子文件夹中。',
+	arr_settings_enabled_name: '启用文件夹排列',
+	arr_settings_enabled_desc: '启用后，所选属性之一发生更改时立即移动行。默认关闭。',
+	arr_settings_no_props: '未选择任何属性。请在下方添加一个以定义文件夹层级。',
+	arr_settings_no_candidates: '没有可用列。文件夹排列支持文本、选择、状态和日期列。',
+	arr_settings_add_placeholder: '选择一个属性...',
+	arr_settings_add_btn: '添加',
+	arr_settings_preview_btn: '预览并应用到现有行',
+	arr_preview_title: '文件夹排列预览',
+	arr_preview_empty: '没有需要移动的行。',
+	arr_preview_desc: '将移动 $count 行：',
+	arr_preview_apply: '应用',
+	arr_preview_cancel: '取消',
+	arr_preview_applied: '已移动 $count 行。',
+
 	// Quick add
 	cmd_quick_add: '快速向数据库添加行',
 	quick_add_title: '快速添加',

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,21 @@ export default class NotionBasesPlugin extends Plugin {
 			})
 		)
 
+		// Folder arrangement: mover linhas para subpastas conforme valores das colunas configuradas
+		this.registerEvent(
+			this.app.metadataCache.on('changed', (file) => {
+				if (!(file instanceof TFile)) return
+				if (file.extension !== 'md') return
+				if (this.manager.isDatabaseFile(file)) return
+				if (this.manager.isArrangementInProgress(file.path)) return
+				const dbFile = this.manager.findGoverningDatabase(file)
+				if (!dbFile) return
+				const config = this.manager.readConfig(dbFile)
+				if (!config.folderArrangement?.enabled) return
+				void this.manager.applyArrangement(file, dbFile, config)
+			})
+		)
+
 		// Embed de database em notas via ```nb-database
 		registerDatabaseEmbed(this)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,11 +145,17 @@ export interface EmbedState {
 
 // ── Database config (stored in _database.md frontmatter) ───────────────────
 
+export interface FolderArrangementConfig {
+	enabled: boolean
+	propertyIds: string[]
+}
+
 export interface DatabaseConfig {
 	schema: ColumnSchema[]
 	views: ViewConfig[]
 	templatePath?: string
 	askTemplateOnCreate?: boolean
+	folderArrangement?: FolderArrangementConfig
 }
 
 export const DEFAULT_VIEW: ViewConfig = {

--- a/styles.css
+++ b/styles.css
@@ -5503,3 +5503,87 @@ body.nb-tl-resizing * {
 .nb-cf-btn--cancel:hover {
 	background: var(--background-modifier-border);
 }
+
+/* Folder arrangement settings UI */
+.nb-db-settings-arrangement {
+	margin-top: 1em;
+	padding-top: 1em;
+	border-top: 1px solid var(--background-modifier-border);
+}
+.nb-db-settings-arrangement-desc {
+	color: var(--text-muted);
+	font-size: 0.9em;
+	margin-top: 0;
+}
+.nb-arr-property-list {
+	margin: 0.5em 0;
+}
+.nb-arr-property-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 8px;
+	margin-bottom: 4px;
+	background: var(--background-secondary);
+	border-radius: 4px;
+}
+.nb-arr-property-index {
+	color: var(--text-muted);
+	font-size: 0.85em;
+	min-width: 18px;
+}
+.nb-arr-property-name {
+	flex: 1;
+	font-weight: 500;
+}
+.nb-arr-btn {
+	min-width: 28px;
+	padding: 2px 8px;
+}
+.nb-arr-btn-remove {
+	color: var(--text-error);
+}
+.nb-arr-add-row {
+	display: flex;
+	gap: 8px;
+	margin-top: 8px;
+	align-items: center;
+}
+.nb-arr-select {
+	flex: 1;
+}
+.nb-arr-empty {
+	color: var(--text-muted);
+	font-size: 0.9em;
+	font-style: italic;
+	margin: 4px 0;
+}
+.nb-arr-preview-btn {
+	margin-top: 12px;
+}
+.nb-arr-preview-list {
+	max-height: 50vh;
+	overflow-y: auto;
+	margin: 8px 0;
+	padding: 8px;
+	background: var(--background-secondary);
+	border-radius: 4px;
+	font-family: var(--font-monospace);
+	font-size: 0.85em;
+}
+.nb-arr-preview-row {
+	display: flex;
+	gap: 8px;
+	padding: 2px 0;
+	white-space: nowrap;
+	overflow-x: auto;
+}
+.nb-arr-preview-from { color: var(--text-muted); }
+.nb-arr-preview-arrow { color: var(--text-accent); }
+.nb-arr-preview-to { color: var(--text-success); }
+.nb-arr-preview-actions {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+	margin-top: 12px;
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -5,6 +5,47 @@ export class TFile {
 	extension = 'md'
 }
 
+export class TFolder {
+	path = ''
+	children: unknown[] = []
+}
+
+export class Modal {}
+export class FuzzySuggestModal<T> {
+	app: unknown
+	constructor(app: unknown) { this.app = app }
+	getItems(): T[] { return [] }
+	getItemText(_: T): string { return '' }
+	onChooseItem(_item: T): void {}
+	open(): void {}
+}
+export class Setting {
+	constructor(_el: unknown) {}
+	setName(): this { return this }
+	setDesc(): this { return this }
+	addText(): this { return this }
+	addToggle(): this { return this }
+	addButton(): this { return this }
+	addExtraButton(): this { return this }
+	addDropdown(): this { return this }
+}
+export class Notice { constructor(_msg: string) {} }
+export class MarkdownRenderChild {
+	containerEl: HTMLElement
+	constructor(el: HTMLElement) { this.containerEl = el }
+	onload(): void {}
+	onunload(): void {}
+}
+
+export function normalizePath(p: string): string {
+	return p.replace(/\\/g, '/').replace(/\/+/g, '/')
+}
+
+export function parseYaml(s: string): unknown {
+	// minimal stub — tests don't rely on actual yaml parsing
+	return s
+}
+
 export interface RowData {
 	[key: string]: unknown
 }

--- a/tests/folder-arrangement.test.ts
+++ b/tests/folder-arrangement.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeSegment } from '../src/database-manager'
+
+describe('sanitizeSegment', () => {
+	it('strips invalid filename characters', () => {
+		expect(sanitizeSegment('a/b\\c:d*e?f"g<h>i|j')).toBe('abcdefghij')
+	})
+
+	it('collapses whitespace', () => {
+		expect(sanitizeSegment('  hello   world  ')).toBe('hello world')
+	})
+
+	it('returns empty string for whitespace-only or empty', () => {
+		expect(sanitizeSegment('   ')).toBe('')
+		expect(sanitizeSegment('')).toBe('')
+	})
+
+	it('preserves accented characters and emoji', () => {
+		expect(sanitizeSegment('Olá Mundo 🌍')).toBe('Olá Mundo 🌍')
+	})
+
+	it('strips only invalid characters, keeps everything else', () => {
+		expect(sanitizeSegment('Done — high priority')).toBe('Done — high priority')
+	})
+})


### PR DESCRIPTION
## Summary
Lets a database be configured with an ordered list of frontmatter properties whose values become a nested folder hierarchy under the database folder. When any of those properties change on a row, the file is moved to match — `Pt1=V1, Pt2=V2` lands at `PF/V1/V2/<name>.md`. Empty values stop the hierarchy at the last filled level.

## What's in
- `DatabaseConfig` gains an optional `folderArrangement { enabled, propertyIds }` persisted in `_database.md` frontmatter. Off by default.
- A global `metadataCache` listener routes changes to `applyArrangement`, which moves the file via `fileManager.renameFile` so internal links stay consistent.
- An in-progress path set guards against rename → metadata → rename loops.
- `_database.md` is excluded from arrangement; folders are created on demand; collisions on the target path are skipped.
- Settings modal grows a Folder arrangement section: enable toggle, ordered property list with up/down/remove, an add dropdown (text/select/status/date columns only), and a `Preview & apply to existing rows` button.
- Preview modal lists every planned `old → new` path before applying in batch — existing rows never move silently.
- Strings localized in all 7 languages.
- Bonus: a separate commit fixes a self-write race in `DatabaseRoot` that made config edits get clobbered by their own metadata-change echo.

## Test plan
- [ ] Configure a database with `[status, priority]` arrangement and a few rows
- [ ] Set `status=Doing` on a row → file moves into `<db>/Doing/`
- [ ] Set `priority=High` → file moves into `<db>/Doing/High/`
- [ ] Change `status=Done` → file moves laterally to `<db>/Done/High/`
- [ ] Clear `priority` → file moves up to `<db>/Done/`
- [ ] Clear `status` → file returns to db root
- [ ] `_database.md` itself is never moved
- [ ] Disable the toggle → property edits no longer trigger moves
- [ ] Use the preview modal to see `oldPath → newPath` for every row, then Apply
- [ ] Verify behavior on Android emulator after deploy

Closes #22