### PR TITLE
fix: subfolder toggle now works on single-view databases (#28)

### DIFF
--- a/src/components/DatabaseRoot.tsx
+++ b/src/components/DatabaseRoot.tsx
@@ -348,7 +348,6 @@ export function DatabaseRoot({
 	}, [config, dbFile, writeConfigAndTrack, activeViewId])
 
 	const activeView = config.views.find(v => v.id === activeViewId) ?? config.views[0] ?? DEFAULT_VIEW
-	const isSingleTableView = config.views.length === 1 && activeView.type === 'table'
 
 	const saveDirectViewNames = async (updatedViews: ViewConfig[]) => {
 		if (!dbFile) return
@@ -441,8 +440,8 @@ export function DatabaseRoot({
 					key={activeViewId}
 					dbFile={dbFile}
 					manager={manager}
-					externalView={isSingleTableView ? undefined : activeView}
-					onViewChange={isSingleTableView ? undefined : handleViewChange}
+					externalView={activeView}
+					onViewChange={handleViewChange}
 				/>
 				: renderView(activeView, handleViewChange, activeViewId)
 			}


### PR DESCRIPTION
## Summary

Issue #28 (reported by @Azmoinal, confirmed by @apzzac): on a database with exactly one Table view, toggling **Include subfolders** in the toolbar appears to do nothing — files from subfolders never show up. Adding a second view (e.g. List) makes the subfolders appear in *both* views; deleting that second view hides them again.

**Root cause** is in `DatabaseRoot.tsx`. When `config.views.length === 1 && activeView.type === 'table'`, the `isSingleTableView` short-circuit passes `externalView={undefined}` to `DatabaseTable`. That value flows into the `useDatabaseRows` hook as `includeSubfolders: externalView?.includeSubfolders` — i.e. `undefined`. When the user toggles the button, the new view config is correctly persisted to disk, the metadata cache fires, and `loadData` re-runs — but it captures the (still `undefined`) `includeSubfolders` from the closure, so notes are fetched without subfolders. Adding a second view sets `isSingleTableView=false`, so `externalView` becomes the actual view object and the hook finally receives the right value; deleting it inverts the cycle.

The `isSingleTableView` short-circuit looks like a leftover from before multi-view support — `DatabaseTable` already handles the single-view case correctly through the multi-view code path. Removing the short-circuit also unifies writes through `writeConfigAndTrack`, which gets self-write debouncing for free.

## Changes

- `src/components/DatabaseRoot.tsx`: drop the `isSingleTableView` constant and always pass `externalView={activeView}` / `onViewChange={handleViewChange}` to `DatabaseTable`.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` clean
- [ ] Manual: database with 1 Table view + files in subfolders → toggle subfolders → files appear immediately (no need to add a second view)
- [ ] Manual: toggle off → files from subfolders disappear
- [ ] Manual: database with Table + Board → toggling subfolders on Table does NOT affect Board (per-view setting preserved)
- [ ] Manual: `nb-database` embed with 1 view → toggle still works (this path was already fine, sanity check)

Closes #28
