### PR TITLE
fix: accept all view types in embed type: parameter

### DIFF
--- a/src/database-embed.ts
+++ b/src/database-embed.ts
@@ -8,6 +8,34 @@ import type NotionBasesPlugin from './main'
 
 const EMBED_FM_KEY = 'notion-bases-embeds'
 
+const VIEW_TYPES: ReadonlyArray<ViewConfig['type']> = ['table', 'list', 'board', 'gallery', 'calendar', 'timeline', 'chart']
+
+export interface EmbedBlockParams {
+	folderPath: string
+	embedId: string
+	forcedType?: ViewConfig['type']
+}
+
+export function parseEmbedBlock(source: string): EmbedBlockParams {
+	let folderPath = ''
+	let embedId = ''
+	let forcedType: ViewConfig['type'] | undefined
+
+	for (const line of source.trim().split('\n')) {
+		const pathMatch = line.match(/^path:\s*(.+)$/)
+		if (pathMatch) folderPath = pathMatch[1].trim()
+		const idMatch = line.match(/^id:\s*(.+)$/)
+		if (idMatch) embedId = idMatch[1].trim()
+		const typeMatch = line.match(/^type:\s*(.+)$/)
+		if (typeMatch) {
+			const t = typeMatch[1].trim()
+			if ((VIEW_TYPES as readonly string[]).includes(t)) forcedType = t as ViewConfig['type']
+		}
+	}
+
+	return { folderPath, embedId, forcedType }
+}
+
 class DatabaseEmbedChild extends MarkdownRenderChild {
 	private root: Root | null = null
 
@@ -46,14 +74,17 @@ class DatabaseEmbedChild extends MarkdownRenderChild {
 			// Mode A — type declared in code block: single forced view, no tabs
 			const savedView = (savedData && typeof savedData === 'object' && !('activeViewId' in savedData)) ? savedData as ViewConfig : undefined
 			const dbFm = this.plugin.app.metadataCache.getFileCache(dbFile)?.frontmatter
-			const dbFirstView = (dbFm as Record<string, unknown[]> | undefined)?.views?.[0] as ViewConfig | undefined
+			const dbViews = (dbFm as Record<string, unknown[]> | undefined)?.views as ViewConfig[] | undefined
+			// Prefer the database view whose type matches the forced type, so
+			// type-specific config (board groupBy, calendar date column, …) carries over
+			const dbBaseView = dbViews?.find(v => v?.type === this.forcedType) ?? dbViews?.[0]
 
 			let externalView: ViewConfig
 			if (savedView) {
 				externalView = { ...savedView, id: this.embedId, type: this.forcedType }
 			} else {
-				externalView = dbFirstView
-					? { ...dbFirstView, id: this.embedId, type: this.forcedType }
+				externalView = dbBaseView
+					? { ...dbBaseView, id: this.embedId, type: this.forcedType }
 					: { ...DEFAULT_VIEW, id: this.embedId, type: this.forcedType }
 			}
 
@@ -104,22 +135,9 @@ class DatabaseEmbedChild extends MarkdownRenderChild {
 
 export function registerDatabaseEmbed(plugin: NotionBasesPlugin): void {
 	plugin.registerMarkdownCodeBlockProcessor('nb-database', (source, el, ctx) => {
-		const lines = source.trim().split('\n')
-		let folderPath = ''
-		let embedId = ''
-		let forcedType: ViewConfig['type'] | undefined
-
-		for (const line of lines) {
-			const pathMatch = line.match(/^path:\s*(.+)$/)
-			if (pathMatch) folderPath = pathMatch[1].trim()
-			const idMatch = line.match(/^id:\s*(.+)$/)
-			if (idMatch) embedId = idMatch[1].trim()
-			const typeMatch = line.match(/^type:\s*(.+)$/)
-			if (typeMatch) {
-				const t = typeMatch[1].trim()
-				if (t === 'table' || t === 'list') forcedType = t
-			}
-		}
+		const parsed = parseEmbedBlock(source)
+		const { folderPath, forcedType } = parsed
+		let embedId = parsed.embedId
 
 		// Generate and persist ID if missing
 		if (!embedId) {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -49,3 +49,7 @@ export function parseYaml(s: string): unknown {
 export interface RowData {
 	[key: string]: unknown
 }
+
+export function getLanguage(): string {
+	return 'en'
+}

--- a/tests/database-embed.test.ts
+++ b/tests/database-embed.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { parseEmbedBlock } from '../src/database-embed'
+
+describe('parseEmbedBlock', () => {
+	it('parses path and id', () => {
+		const result = parseEmbedBlock('id: nb12345678\npath: Projects/Tasks\n')
+		expect(result.folderPath).toBe('Projects/Tasks')
+		expect(result.embedId).toBe('nb12345678')
+		expect(result.forcedType).toBeUndefined()
+	})
+
+	it.each(['table', 'list', 'board', 'gallery', 'calendar', 'timeline', 'chart'] as const)(
+		'accepts view type %s',
+		(type) => {
+			const result = parseEmbedBlock(`path: Foo\ntype: ${type}`)
+			expect(result.forcedType).toBe(type)
+		},
+	)
+
+	it('ignores unknown view types', () => {
+		expect(parseEmbedBlock('path: Foo\ntype: kanban').forcedType).toBeUndefined()
+		expect(parseEmbedBlock('path: Foo\ntype: ').forcedType).toBeUndefined()
+	})
+
+	it('trims whitespace around values', () => {
+		const result = parseEmbedBlock('path:   My/Folder  \ntype:  board ')
+		expect(result.folderPath).toBe('My/Folder')
+		expect(result.forcedType).toBe('board')
+	})
+
+	it('returns empty strings when path and id are missing', () => {
+		const result = parseEmbedBlock('type: board')
+		expect(result.folderPath).toBe('')
+		expect(result.embedId).toBe('')
+	})
+
+	it('last occurrence wins when a key is repeated', () => {
+		const result = parseEmbedBlock('type: board\ntype: calendar')
+		expect(result.forcedType).toBe('calendar')
+	})
+})


### PR DESCRIPTION
The nb-database block parser only accepted table and list in the type: parameter, silently ignoring board, gallery, calendar, timeline and chart. The parser was extracted into a pure, unit-tested function that accepts every view type, and forced-type embeds now inherit config from the database view whose type matches the request instead of always cloning the first view.

Closes #33