### PR TITLE
fix: hardcoded Portuguese Campos label in calendar fields button

### DIFF
--- a/src/components/DatabaseCalendar.tsx
+++ b/src/components/DatabaseCalendar.tsx
@@ -491,7 +491,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 				{/* Campos */}
 				<div className="nb-fields-menu-wrapper" ref={fieldsMenuRef}>
 					<button className={`nb-toolbar-btn${fieldsMenuOpen ? ' nb-toolbar-btn--active' : ''}`} onClick={() => setFieldsMenuOpen(v => !v)}>
-						Campos
+						{t('fields')}
 					</button>
 					{fieldsMenuOpen && (
 						<div className="nb-fields-dropdown">


### PR DESCRIPTION
The calendar toolbar fields button bypassed t() with a literal PT string, showing Campos on English UIs. Same family as the earlier Limpar fix. Found while capturing product screenshots for the landing page.