### PR TITLE
feat: add date and time functions to formula engine

### DIFF
--- a/src/components/ColumnHeader.tsx
+++ b/src/components/ColumnHeader.tsx
@@ -690,6 +690,17 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 			{ fn: 'POWER(b, e)',  desc: t('formula_desc_power') },
 			{ fn: 'SQRT(n)',      desc: t('formula_desc_sqrt') },
 		]},
+		{ group: t('formula_group_date'), items: [
+			{ fn: 'NOW()',                       desc: t('formula_desc_now') },
+			{ fn: 'TODAY()',                     desc: t('formula_desc_today') },
+			{ fn: 'DATE(y, m, d)',               desc: t('formula_desc_date') },
+			{ fn: 'YEAR / MONTH / DAY(date)',    desc: t('formula_desc_date_parts') },
+			{ fn: 'HOUR / MINUTE(date)',         desc: t('formula_desc_time_parts') },
+			{ fn: 'WEEKDAY(date)',               desc: t('formula_desc_weekday') },
+			{ fn: 'DATEDIF(start, end, unit)',   desc: t('formula_desc_datedif') },
+			{ fn: 'DATEADD(date, n, unit)',      desc: t('formula_desc_dateadd') },
+			{ fn: 'FORMATDATE(d, "DD/MM/YYYY")', desc: t('formula_desc_formatdate') },
+		]},
 		{ group: t('formula_group_utils'), items: [
 			{ fn: 'ISNULL(v)',         desc: t('formula_desc_isnull') },
 			{ fn: 'COALESCE(a, b, …)', desc: t('formula_desc_coalesce') },

--- a/src/formula-engine.ts
+++ b/src/formula-engine.ts
@@ -197,13 +197,78 @@ function toNum(v: unknown): number {
 	if (typeof v === 'number') return isNaN(v) ? 0 : v
 	if (typeof v === 'string') { const n = parseFloat(v); return isNaN(n) ? 0 : n }
 	if (typeof v === 'boolean') return v ? 1 : 0
+	if (v instanceof Date) return v.getTime()
 	return 0
 }
 
 function toStr(v: unknown): string {
 	if (v === null || v === undefined) return ''
 	if (Array.isArray(v)) return (v as unknown[]).map(toStr).join(', ')
+	if (v instanceof Date) return formatDateValue(v)
 	return stringifyScalar(v)
+}
+
+// ── Datas ─────────────────────────────────────────────────────────────────────
+
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Converte um valor em Date. Strings "YYYY-MM-DD" são interpretadas como data
+ * LOCAL (new Date("YYYY-MM-DD") usaria UTC e erraria o dia em fusos negativos).
+ */
+function toDate(v: unknown): Date | null {
+	if (v instanceof Date) return isNaN(v.getTime()) ? null : v
+	if (typeof v === 'number') { const d = new Date(v); return isNaN(d.getTime()) ? null : d }
+	if (typeof v === 'string') {
+		const s = v.trim()
+		if (!s) return null
+		if (DATE_ONLY_RE.test(s)) {
+			const [y, m, d] = s.split('-').map(Number)
+			return new Date(y, m - 1, d)
+		}
+		const t = Date.parse(s.includes(' ') ? s.replace(' ', 'T') : s)
+		return isNaN(t) ? null : new Date(t)
+	}
+	return null
+}
+
+function pad2(n: number): string { return String(n).padStart(2, '0') }
+
+/** "YYYY-MM-DD" para datas à meia-noite, "YYYY-MM-DD HH:mm" quando há horário. */
+function formatDateValue(d: Date): string {
+	const datePart = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
+	if (d.getHours() === 0 && d.getMinutes() === 0 && d.getSeconds() === 0) return datePart
+	return `${datePart} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`
+}
+
+function formatDatePattern(d: Date, fmt: string): string {
+	return fmt.replace(/YYYY|YY|MM|DD|HH|mm|ss/g, tok => {
+		switch (tok) {
+			case 'YYYY': return String(d.getFullYear())
+			case 'YY': return String(d.getFullYear() % 100).padStart(2, '0')
+			case 'MM': return pad2(d.getMonth() + 1)
+			case 'DD': return pad2(d.getDate())
+			case 'HH': return pad2(d.getHours())
+			case 'mm': return pad2(d.getMinutes())
+			case 'ss': return pad2(d.getSeconds())
+			default: return tok
+		}
+	})
+}
+
+type DateUnit = 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes'
+
+function toDateUnit(v: unknown): DateUnit | null {
+	const s = toStr(v).trim().toLowerCase()
+	switch (s) {
+		case 'y': case 'year': case 'years': return 'years'
+		case 'm': case 'month': case 'months': return 'months'
+		case 'w': case 'week': case 'weeks': return 'weeks'
+		case '': case 'd': case 'day': case 'days': return 'days'
+		case 'h': case 'hour': case 'hours': return 'hours'
+		case 'min': case 'minute': case 'minutes': return 'minutes'
+		default: return null
+	}
 }
 
 function truthy(v: unknown): boolean {
@@ -211,9 +276,26 @@ function truthy(v: unknown): boolean {
 }
 
 function eqVal(a: unknown, b: unknown): boolean {
+	if (a instanceof Date || b instanceof Date) {
+		const da = toDate(a), db = toDate(b)
+		if (da && db) return da.getTime() === db.getTime()
+	}
 	const as = typeof a === 'string' ? a.toLowerCase() : a
 	const bs = typeof b === 'string' ? b.toLowerCase() : b
 	return as == bs
+}
+
+/**
+ * Valor numérico para comparações ordenadas. Quando um dos lados é Date,
+ * ambos são coeridos via toDate para que `[due] < TODAY()` funcione com a
+ * coluna vinda do frontmatter como string ISO.
+ */
+function cmpPair(a: unknown, b: unknown): [number, number] {
+	if (a instanceof Date || b instanceof Date) {
+		const da = toDate(a), db = toDate(b)
+		if (da && db) return [da.getTime(), db.getTime()]
+	}
+	return [toNum(a), toNum(b)]
 }
 
 // ── Resolução de colunas ──────────────────────────────────────────────────────
@@ -260,6 +342,8 @@ const KNOWN_FNS = new Set([
 	'ROUND', 'FLOOR', 'CEIL', 'ABS', 'MOD', 'POWER', 'SQRT',
 	'ISNULL', 'ISEMPTY', 'COALESCE',
 	'TEXT', 'VALUE',
+	'NOW', 'TODAY', 'DATE', 'YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE',
+	'WEEKDAY', 'DATEDIF', 'DATEDIFF', 'DATEADD', 'FORMATDATE',
 ])
 
 // ── Avaliador ─────────────────────────────────────────────────────────────────
@@ -284,10 +368,10 @@ function evalNode(n: Node, ctx: Ctx): unknown {
 				case '&': return toStr(lv) + toStr(rv)
 				case '=': case '==': return eqVal(lv, rv)
 				case '<>': case '!=': return !eqVal(lv, rv)
-				case '>':  return toNum(lv) > toNum(rv)
-				case '<':  return toNum(lv) < toNum(rv)
-				case '>=': return toNum(lv) >= toNum(rv)
-				case '<=': return toNum(lv) <= toNum(rv)
+				case '>':  { const [a, b] = cmpPair(lv, rv); return a > b }
+				case '<':  { const [a, b] = cmpPair(lv, rv); return a < b }
+				case '>=': { const [a, b] = cmpPair(lv, rv); return a >= b }
+				case '<=': { const [a, b] = cmpPair(lv, rv); return a <= b }
 				default: throw new FormulaError(`Operador desconhecido: ${op}`)
 			}
 		}
@@ -462,6 +546,87 @@ function evalNode(n: Node, ctx: Ctx): unknown {
 			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
 			case_VALUE: if (fn === 'VALUE') { return args.length === 1 ? toNum(evalNode(args[0], ctx)) : null }
 
+			// ── Datas ──
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_NOW: if (fn === 'NOW') {
+				if (args.length !== 0) throw new FormulaError('NOW()')
+				return new Date()
+			}
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_TODAY: if (fn === 'TODAY') {
+				if (args.length !== 0) throw new FormulaError('TODAY()')
+				const d = new Date()
+				return new Date(d.getFullYear(), d.getMonth(), d.getDate())
+			}
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_DATE: if (fn === 'DATE') {
+				if (args.length !== 3) throw new FormulaError('DATE(ano, mes, dia)')
+				return new Date(toNum(evalNode(args[0], ctx)), toNum(evalNode(args[1], ctx)) - 1, toNum(evalNode(args[2], ctx)))
+			}
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_DATEPART: if (fn === 'YEAR' || fn === 'MONTH' || fn === 'DAY' || fn === 'HOUR' || fn === 'MINUTE' || fn === 'WEEKDAY') {
+				if (args.length !== 1) throw new FormulaError(`${fn}(data)`)
+				const d = toDate(evalNode(args[0], ctx))
+				if (!d) return null
+				switch (fn) {
+					case 'YEAR': return d.getFullYear()
+					case 'MONTH': return d.getMonth() + 1
+					case 'DAY': return d.getDate()
+					case 'HOUR': return d.getHours()
+					case 'MINUTE': return d.getMinutes()
+					default: return d.getDay() + 1 // WEEKDAY: 1 = domingo … 7 = sábado
+				}
+			}
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_DATEDIF: if (fn === 'DATEDIF' || fn === 'DATEDIFF') {
+				if (args.length < 2 || args.length > 3) throw new FormulaError('DATEDIF(inicio, fim, unidade?)')
+				const a = toDate(evalNode(args[0], ctx))
+				const b = toDate(evalNode(args[1], ctx))
+				if (!a || !b) return null
+				const unit = toDateUnit(args[2] ? evalNode(args[2], ctx) : '')
+				if (!unit) throw new FormulaError('DATEDIF: unidade deve ser years, months, weeks, days, hours ou minutes')
+				// Dias por componentes de calendário (imune a DST), tempo por diferença bruta
+				const calDays = Math.round((Date.UTC(b.getFullYear(), b.getMonth(), b.getDate()) - Date.UTC(a.getFullYear(), a.getMonth(), a.getDate())) / 86400000)
+				switch (unit) {
+					case 'days': return calDays
+					case 'weeks': return Math.trunc(calDays / 7)
+					case 'hours': return Math.trunc((b.getTime() - a.getTime()) / 3600000)
+					case 'minutes': return Math.trunc((b.getTime() - a.getTime()) / 60000)
+					case 'months': case 'years': {
+						let months = (b.getFullYear() - a.getFullYear()) * 12 + (b.getMonth() - a.getMonth())
+						if (months > 0 && b.getDate() < a.getDate()) months--
+						else if (months < 0 && b.getDate() > a.getDate()) months++
+						return unit === 'months' ? months : Math.trunc(months / 12)
+					}
+				}
+			}
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_DATEADD: if (fn === 'DATEADD') {
+				if (args.length < 2 || args.length > 3) throw new FormulaError('DATEADD(data, n, unidade?)')
+				const d = toDate(evalNode(args[0], ctx))
+				if (!d) return null
+				const n = Math.trunc(toNum(evalNode(args[1], ctx)))
+				const unit = toDateUnit(args[2] ? evalNode(args[2], ctx) : '')
+				if (!unit) throw new FormulaError('DATEADD: unidade deve ser years, months, weeks, days, hours ou minutes')
+				const r = new Date(d.getTime())
+				switch (unit) {
+					case 'years': r.setFullYear(r.getFullYear() + n); break
+					case 'months': r.setMonth(r.getMonth() + n); break
+					case 'weeks': r.setDate(r.getDate() + n * 7); break
+					case 'days': r.setDate(r.getDate() + n); break
+					case 'hours': r.setHours(r.getHours() + n); break
+					case 'minutes': r.setMinutes(r.getMinutes() + n); break
+				}
+				return r
+			}
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_FORMATDATE: if (fn === 'FORMATDATE') {
+				if (args.length !== 2) throw new FormulaError('FORMATDATE(data, formato)')
+				const d = toDate(evalNode(args[0], ctx))
+				if (!d) return null
+				return formatDatePattern(d, toStr(evalNode(args[1], ctx)))
+			}
+
 			throw new FormulaError(i18n('formula_err_not_implemented').replace('$fn', fn))
 		}
 	}
@@ -519,7 +684,9 @@ export function evaluateFormula(
 	try {
 		const ast = new Parser(tokenize(formula)).parse()
 		const formulaColIds = new Set(schema.filter(c => c.type === 'formula').map(c => c.id))
-		return evalNode(ast, { row, allRows, schema, formulaColIds })
+		const result = evalNode(ast, { row, allRows, schema, formulaColIds })
+		// Date só existe como valor intermediário — a célula recebe string formatada
+		return result instanceof Date ? formatDateValue(result) : result
 	} catch {
 		return '#ERRO'
 	}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -172,6 +172,7 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	formula_group_aggregators: 'Aggregatoren',
 	formula_group_text: 'Text',
 	formula_group_math: 'Mathematik',
+	formula_group_date: 'Datum und Uhrzeit',
 	formula_group_utils: 'Hilfsfunktionen',
 
 	// Formula reference descriptions
@@ -200,6 +201,15 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	formula_desc_mod: 'Rest der Division',
 	formula_desc_power: 'Basis hoch Exponent',
 	formula_desc_sqrt: 'Quadratwurzel',
+	formula_desc_now: 'Aktuelles Datum und aktuelle Uhrzeit',
+	formula_desc_today: 'Aktuelles Datum um Mitternacht',
+	formula_desc_date: 'Erstellt ein Datum aus Jahr, Monat und Tag',
+	formula_desc_date_parts: 'Jahr / Monat / Tag eines Datums',
+	formula_desc_time_parts: 'Stunde / Minute eines Datums',
+	formula_desc_weekday: 'Wochentag (1 = Sonntag … 7 = Samstag)',
+	formula_desc_datedif: 'Differenz zwischen zwei Daten in der angegebenen Einheit',
+	formula_desc_dateadd: 'Addiert n Einheiten zu einem Datum (Tage, Monate, Jahre…)',
+	formula_desc_formatdate: 'Formatiert ein Datum mit einem Muster',
 	formula_desc_isnull: 'Wahr wenn v leer oder null ist',
 	formula_desc_coalesce: 'Erster nicht leerer Wert',
 	formula_desc_text: 'Konvertiert in Text',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -170,6 +170,7 @@ const en = {
 	formula_group_aggregators: 'Aggregators',
 	formula_group_text: 'Text',
 	formula_group_math: 'Math',
+	formula_group_date: 'Date and time',
 	formula_group_utils: 'Utilities',
 
 	// Formula reference descriptions
@@ -198,6 +199,15 @@ const en = {
 	formula_desc_mod: 'Remainder of division',
 	formula_desc_power: 'Base raised to exponent',
 	formula_desc_sqrt: 'Square root',
+	formula_desc_now: 'Current date and time',
+	formula_desc_today: 'Current date at midnight',
+	formula_desc_date: 'Builds a date from year, month and day',
+	formula_desc_date_parts: 'Year / month / day of a date',
+	formula_desc_time_parts: 'Hour / minute of a date',
+	formula_desc_weekday: 'Day of the week (1 = sun … 7 = sat)',
+	formula_desc_datedif: 'Difference between two dates in the given unit',
+	formula_desc_dateadd: 'Adds n units to a date (days, months, years…)',
+	formula_desc_formatdate: 'Formats a date using a pattern',
 	formula_desc_isnull: 'True if v is empty or null',
 	formula_desc_coalesce: 'First non-empty value',
 	formula_desc_text: 'Converts to text',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -172,6 +172,7 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	formula_group_aggregators: 'Agregadores',
 	formula_group_text: 'Texto',
 	formula_group_math: 'Matemáticas',
+	formula_group_date: 'Fecha y hora',
 	formula_group_utils: 'Utilidades',
 
 	// Formula reference descriptions
@@ -200,6 +201,15 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	formula_desc_mod: 'Resto de la división',
 	formula_desc_power: 'Base elevada al exponente',
 	formula_desc_sqrt: 'Raíz cuadrada',
+	formula_desc_now: 'Fecha y hora actuales',
+	formula_desc_today: 'Fecha actual a medianoche',
+	formula_desc_date: 'Crea una fecha a partir de año, mes y día',
+	formula_desc_date_parts: 'Año / mes / día de una fecha',
+	formula_desc_time_parts: 'Hora / minuto de una fecha',
+	formula_desc_weekday: 'Día de la semana (1 = domingo … 7 = sábado)',
+	formula_desc_datedif: 'Diferencia entre dos fechas en la unidad indicada',
+	formula_desc_dateadd: 'Añade n unidades a una fecha (días, meses, años…)',
+	formula_desc_formatdate: 'Formatea una fecha usando un patrón',
 	formula_desc_isnull: 'Verdadero si v está vacío o es nulo',
 	formula_desc_coalesce: 'Primer valor no vacío',
 	formula_desc_text: 'Convierte a texto',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -172,6 +172,7 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	formula_group_aggregators: 'Agrégateurs',
 	formula_group_text: 'Texte',
 	formula_group_math: 'Mathématiques',
+	formula_group_date: 'Date et heure',
 	formula_group_utils: 'Utilitaires',
 
 	// Formula reference descriptions
@@ -200,6 +201,15 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	formula_desc_mod: 'Reste de la division',
 	formula_desc_power: 'Base élevée à l\'exposant',
 	formula_desc_sqrt: 'Racine carrée',
+	formula_desc_now: 'Date et heure actuelles',
+	formula_desc_today: 'Date actuelle à minuit',
+	formula_desc_date: 'Construit une date à partir de l\'année, du mois et du jour',
+	formula_desc_date_parts: 'Année / mois / jour d\'une date',
+	formula_desc_time_parts: 'Heure / minute d\'une date',
+	formula_desc_weekday: 'Jour de la semaine (1 = dimanche … 7 = samedi)',
+	formula_desc_datedif: 'Différence entre deux dates dans l\'unité donnée',
+	formula_desc_dateadd: 'Ajoute n unités à une date (jours, mois, années…)',
+	formula_desc_formatdate: 'Formate une date selon un motif',
 	formula_desc_isnull: 'Vrai si v est vide ou nul',
 	formula_desc_coalesce: 'Première valeur non vide',
 	formula_desc_text: 'Convertit en texte',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -172,6 +172,7 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	formula_group_aggregators: '集計',
 	formula_group_text: 'テキスト',
 	formula_group_math: '数学',
+	formula_group_date: '日付と時刻',
 	formula_group_utils: 'ユーティリティ',
 
 	// Formula reference descriptions
@@ -200,6 +201,15 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	formula_desc_mod: '除算の余り',
 	formula_desc_power: '底の指数乗',
 	formula_desc_sqrt: '平方根',
+	formula_desc_now: '現在の日付と時刻',
+	formula_desc_today: '当日の午前 0 時の日付',
+	formula_desc_date: '年・月・日から日付を作成する',
+	formula_desc_date_parts: '日付の年 / 月 / 日',
+	formula_desc_time_parts: '日付の時 / 分',
+	formula_desc_weekday: '曜日（1 = 日曜 … 7 = 土曜）',
+	formula_desc_datedif: '指定した単位での 2 つの日付の差',
+	formula_desc_dateadd: '日付に n 単位を加算する（日、月、年など）',
+	formula_desc_formatdate: 'パターンで日付をフォーマットする',
 	formula_desc_isnull: 'v が空または null のとき真',
 	formula_desc_coalesce: '最初の空でない値',
 	formula_desc_text: 'テキストに変換する',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -172,6 +172,7 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	formula_group_aggregators: 'Agregadores',
 	formula_group_text: 'Texto',
 	formula_group_math: 'Matemática',
+	formula_group_date: 'Data e hora',
 	formula_group_utils: 'Utilitários',
 
 	// Formula reference descriptions
@@ -200,6 +201,15 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	formula_desc_mod: 'Resto da divisão',
 	formula_desc_power: 'Base elevada ao expoente',
 	formula_desc_sqrt: 'Raiz quadrada',
+	formula_desc_now: 'Data e hora atuais',
+	formula_desc_today: 'Data atual à meia-noite',
+	formula_desc_date: 'Cria uma data a partir de ano, mês e dia',
+	formula_desc_date_parts: 'Ano / mês / dia de uma data',
+	formula_desc_time_parts: 'Hora / minuto de uma data',
+	formula_desc_weekday: 'Dia da semana (1 = domingo … 7 = sábado)',
+	formula_desc_datedif: 'Diferença entre duas datas na unidade indicada',
+	formula_desc_dateadd: 'Adiciona n unidades a uma data (dias, meses, anos…)',
+	formula_desc_formatdate: 'Formata uma data usando um padrão',
 	formula_desc_isnull: 'Verdadeiro se v estiver vazio ou nulo',
 	formula_desc_coalesce: 'Primeiro valor não vazio',
 	formula_desc_text: 'Converte para texto',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -172,6 +172,7 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	formula_group_aggregators: '聚合',
 	formula_group_text: '文本',
 	formula_group_math: '数学',
+	formula_group_date: '日期和时间',
 	formula_group_utils: '工具',
 
 	// Formula reference descriptions
@@ -200,6 +201,15 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	formula_desc_mod: '除法余数',
 	formula_desc_power: '底数的指数次幂',
 	formula_desc_sqrt: '平方根',
+	formula_desc_now: '当前日期和时间',
+	formula_desc_today: '当天零点的日期',
+	formula_desc_date: '根据年、月、日创建日期',
+	formula_desc_date_parts: '日期的年 / 月 / 日',
+	formula_desc_time_parts: '日期的时 / 分',
+	formula_desc_weekday: '星期几（1 = 星期日 … 7 = 星期六）',
+	formula_desc_datedif: '两个日期在指定单位下的差值',
+	formula_desc_dateadd: '为日期加上 n 个单位（天、月、年……）',
+	formula_desc_formatdate: '按指定模式格式化日期',
 	formula_desc_isnull: '若 v 为空或 null 则为真',
 	formula_desc_coalesce: '第一个非空值',
 	formula_desc_text: '转换为文本',

--- a/tests/formula-engine.test.ts
+++ b/tests/formula-engine.test.ts
@@ -270,6 +270,101 @@ describe('conversion functions', () => {
 	})
 })
 
+// ── Date functions ───────────────────────────────────────────────────────────
+
+describe('date functions', () => {
+	it('NOW returns current date and time', () => {
+		const before = new Date()
+		const result = evalF('NOW()') as string
+		expect(typeof result).toBe('string')
+		expect(result).toMatch(/^\d{4}-\d{2}-\d{2}/)
+		expect(new Date(result.replace(' ', 'T')).getFullYear()).toBe(before.getFullYear())
+	})
+
+	it('TODAY returns current date without time', () => {
+		const now = new Date()
+		const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+		expect(evalF('TODAY()')).toBe(expected)
+	})
+
+	it('DATE builds a date', () => {
+		expect(evalF('DATE(2026, 7, 15)')).toBe('2026-07-15')
+	})
+
+	it('YEAR / MONTH / DAY extract date parts', () => {
+		expect(evalF('YEAR("2026-07-15")')).toBe(2026)
+		expect(evalF('MONTH("2026-07-15")')).toBe(7)
+		expect(evalF('DAY("2026-07-15")')).toBe(15)
+	})
+
+	it('date parts parse "YYYY-MM-DD" as local date (no UTC off-by-one)', () => {
+		// In negative timezones new Date("2026-01-01") would be Dec 31 local
+		expect(evalF('DAY("2026-01-01")')).toBe(1)
+		expect(evalF('MONTH("2026-01-01")')).toBe(1)
+	})
+
+	it('HOUR / MINUTE extract time parts', () => {
+		expect(evalF('HOUR("2026-07-15 14:30")')).toBe(14)
+		expect(evalF('MINUTE("2026-07-15 14:30")')).toBe(30)
+	})
+
+	it('WEEKDAY returns 1 for Sunday through 7 for Saturday', () => {
+		expect(evalF('WEEKDAY("2026-07-12")')).toBe(1) // Sunday
+		expect(evalF('WEEKDAY("2026-07-15")')).toBe(4) // Wednesday
+		expect(evalF('WEEKDAY("2026-07-18")')).toBe(7) // Saturday
+	})
+
+	it('date part functions return null for empty or invalid dates', () => {
+		expect(evalF('YEAR(name)', { name: null })).toBeNull()
+		expect(evalF('YEAR("not a date")')).toBeNull()
+	})
+
+	it('DATEDIF in days by default', () => {
+		expect(evalF('DATEDIF("2026-07-01", "2026-07-15")')).toBe(14)
+		expect(evalF('DATEDIF("2026-07-15", "2026-07-01")')).toBe(-14)
+	})
+
+	it('DATEDIF with explicit units', () => {
+		expect(evalF('DATEDIF("2026-01-01", "2026-07-15", "days")')).toBe(195)
+		expect(evalF('DATEDIF("2026-07-01", "2026-07-15", "weeks")')).toBe(2)
+		expect(evalF('DATEDIF("2026-01-31", "2026-03-01", "months")')).toBe(1)
+		expect(evalF('DATEDIF("2020-07-15", "2026-07-14", "years")')).toBe(5)
+		expect(evalF('DATEDIF("2020-07-15", "2026-07-15", "years")')).toBe(6)
+		expect(evalF('DATEDIF("2026-07-15 10:00", "2026-07-15 14:30", "hours")')).toBe(4)
+		expect(evalF('DATEDIF("2026-07-15 10:00", "2026-07-15 10:45", "minutes")')).toBe(45)
+	})
+
+	it('DATEDIF accepts DATEDIFF alias and column values', () => {
+		expect(evalF('DATEDIFF(name, "2026-07-15")', { name: '2026-07-10' })).toBe(5)
+	})
+
+	it('DATEADD adds units to a date', () => {
+		expect(evalF('DATEADD("2026-07-15", 10)')).toBe('2026-07-25')
+		expect(evalF('DATEADD("2026-07-15", 2, "weeks")')).toBe('2026-07-29')
+		expect(evalF('DATEADD("2026-07-15", 3, "months")')).toBe('2026-10-15')
+		expect(evalF('DATEADD("2026-07-15", 1, "years")')).toBe('2027-07-15')
+		expect(evalF('DATEADD("2026-07-15", -15, "days")')).toBe('2026-06-30')
+		expect(evalF('DATEADD("2026-07-15 10:00", 5, "hours")')).toBe('2026-07-15 15:00')
+	})
+
+	it('FORMATDATE formats with pattern tokens', () => {
+		expect(evalF('FORMATDATE("2026-07-15", "DD/MM/YYYY")')).toBe('15/07/2026')
+		expect(evalF('FORMATDATE("2026-07-15 09:05", "YYYY-MM-DD HH:mm")')).toBe('2026-07-15 09:05')
+		expect(evalF('FORMATDATE("2026-07-15", "MM/DD/YY")')).toBe('07/15/26')
+	})
+
+	it('dates compare against date columns', () => {
+		expect(evalF('name < TODAY()', { name: '2020-01-01' })).toBe(true)
+		expect(evalF('name > TODAY()', { name: '2999-01-01' })).toBe(true)
+		expect(evalF('TODAY() = TODAY()')).toBe(true)
+	})
+
+	it('date functions compose', () => {
+		expect(evalF('IF(DATEDIF(name, "2026-07-15") > 7, "old", "recent")', { name: '2026-07-01' })).toBe('old')
+		expect(evalF('FORMATDATE(DATEADD("2026-12-30", 5), "DD/MM")')).toBe('04/01')
+	})
+})
+
 // ── Error handling ───────────────────────────────────────────────────────────
 
 describe('error handling', () => {


### PR DESCRIPTION
## Summary

Adds date/time support to the formula engine: `NOW`, `TODAY`, `DATE`, `YEAR`, `MONTH`, `DAY`, `HOUR`, `MINUTE`, `WEEKDAY`, `DATEDIF`/`DATEDIFF`, `DATEADD` and `FORMATDATE`, plus date-aware comparison operators so expressions like `[due] < TODAY()` work against frontmatter date strings.

## Details

- Date-only strings (`"YYYY-MM-DD"`) are parsed as **local** dates, avoiding the classic UTC off-by-one in negative timezones
- `DATEDIF` counts calendar days from date components, so results are DST-safe; `months`/`years` return whole calendar units
- `DATEADD` supports `years`, `months`, `weeks`, `days`, `hours`, `minutes` (with short aliases)
- `FORMATDATE` supports `YYYY`, `YY`, `MM`, `DD`, `HH`, `mm`, `ss` tokens
- `Date` values only exist as intermediates — cells always receive formatted strings (`YYYY-MM-DD`, with `HH:mm` when there is a time component)
- Formula reference panel gains a "Date and time" group, localized in all 7 languages

## Testing

- 15 new unit tests covering local parsing, `DATEDIF` units, negative `DATEADD`, format tokens, date comparisons and function composition
- Full suite: 177 tests passing, lint clean, production build ok

Part of #40 (phase 1 — date functions; the JS syntax discussion continues in the issue).
