### PR TITLE
feat: add per-column clip option for text overflow

### DIFF
--- a/src/components/ColumnHeader.tsx
+++ b/src/components/ColumnHeader.tsx
@@ -1188,13 +1188,22 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 					))}
 
 					{(col.type === 'text' || col.type === 'title' || col.type === 'url' || col.type === 'email' || col.type === 'phone') && (
-						<button
-							className="nb-menu-item"
-							onClick={() => { void updateCol({ wrap: !col.wrap }); setMenuOpen(false) }}
-						>
-							<span className="nb-menu-item-icon">↵</span>
-							<span>{col.wrap ? t('disable_wrap_text') : t('enable_wrap_text')}</span>
-						</button>
+						<>
+							<button
+								className="nb-menu-item"
+								onClick={() => { void updateCol({ wrap: !col.wrap, clip: false }); setMenuOpen(false) }}
+							>
+								<span className="nb-menu-item-icon">↵</span>
+								<span>{col.wrap ? t('disable_wrap_text') : t('enable_wrap_text')}</span>
+							</button>
+							<button
+								className="nb-menu-item"
+								onClick={() => { void updateCol({ clip: !col.clip, wrap: false }); setMenuOpen(false) }}
+							>
+								<span className="nb-menu-item-icon">⋯</span>
+								<span>{col.clip ? t('disable_clip_text') : t('enable_clip_text')}</span>
+							</button>
+						</>
 					)}
 
 					<div className="nb-menu-separator" />

--- a/src/components/DatabaseTable.tsx
+++ b/src/components/DatabaseTable.tsx
@@ -145,12 +145,14 @@ function VirtualTbody({ scrollRef, rowHeight, rows, stickyMap, isMobile, setEdit
 								const cfStyle = conditionalFormats?.length && schema
 									? getConditionalStyle(row.original, cell.column.id, conditionalFormats, schema)
 									: undefined
-								const wrapCell = !!schema?.find(s => s.id === cell.column.id)?.wrap
+								const cellSchema = schema?.find(s => s.id === cell.column.id)
+								const clipCell = !!cellSchema?.clip
+								const wrapCell = !!cellSchema?.wrap && !clipCell
 								return (
 									<td
 										key={cell.id}
 										data-col-id={cell.column.id}
-										className={['nb-td', sticky ? 'nb-td--sticky' : '', sticky?.isLast ? 'nb-td--sticky-last' : '', wrapCell ? 'nb-td--wrap' : ''].filter(Boolean).join(' ')}
+										className={['nb-td', sticky ? 'nb-td--sticky' : '', sticky?.isLast ? 'nb-td--sticky-last' : '', wrapCell ? 'nb-td--wrap' : '', clipCell ? 'nb-td--clip' : ''].filter(Boolean).join(' ')}
 										style={{ width: cell.column.getSize(), ...(sticky ? { left: sticky.left, zIndex: 1 } : {}), ...cfStyle }}
 										onClick={e => e.stopPropagation()}
 									>

--- a/src/components/cells/CellRenderer.tsx
+++ b/src/components/cells/CellRenderer.tsx
@@ -384,6 +384,7 @@ function TextCell({ value, isEditing, onStartEdit, onCommit, onCancel, onOpen }:
 			<div
 				className="nb-cell-text nb-cell-clickable nb-cell-editable"
 				onDoubleClick={handleDoubleClick}
+				title={value || undefined}
 			>
 				{onOpen ? (
 					<span className="nb-cell-title-link" onClick={handleTextClick}>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -99,6 +99,8 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	hide_field: 'Feld ausblenden',
 	enable_wrap_text: 'Text umbrechen',
 	disable_wrap_text: 'Umbruch deaktivieren',
+	enable_clip_text: 'Text abschneiden',
+	disable_clip_text: 'Abschneiden deaktivieren',
 	delete_field: 'Feld löschen',
 
 	// Column types

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -97,6 +97,8 @@ const en = {
 	hide_field: 'Hide field',
 	enable_wrap_text: 'Wrap text',
 	disable_wrap_text: 'Unwrap text',
+	enable_clip_text: 'Clip text',
+	disable_clip_text: 'Disable clip',
 	delete_field: 'Delete field',
 
 	// Column types

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -99,6 +99,8 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	hide_field: 'Ocultar campo',
 	enable_wrap_text: 'Ajustar texto',
 	disable_wrap_text: 'No ajustar texto',
+	enable_clip_text: 'Cortar texto',
+	disable_clip_text: 'Desactivar corte',
 	delete_field: 'Eliminar campo',
 
 	// Column types

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -99,6 +99,8 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	hide_field: 'Masquer le champ',
 	enable_wrap_text: 'Retour à la ligne',
 	disable_wrap_text: 'Désactiver le retour à la ligne',
+	enable_clip_text: 'Tronquer le texte',
+	disable_clip_text: 'Désactiver la troncature',
 	delete_field: 'Supprimer le champ',
 
 	// Column types

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -99,6 +99,8 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	hide_field: 'フィールドを非表示',
 	enable_wrap_text: 'テキストを折り返す',
 	disable_wrap_text: '折り返しを解除',
+	enable_clip_text: 'テキストを切り詰める',
+	disable_clip_text: '切り詰めを解除',
 	delete_field: 'フィールドを削除',
 
 	// Column types

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -99,6 +99,8 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	hide_field: 'Ocultar campo',
 	enable_wrap_text: 'Quebrar texto',
 	disable_wrap_text: 'Não quebrar texto',
+	enable_clip_text: 'Cortar texto',
+	disable_clip_text: 'Desativar corte',
 	delete_field: 'Excluir campo',
 
 	// Column types

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -99,6 +99,8 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	hide_field: '隐藏字段',
 	enable_wrap_text: '自动换行',
 	disable_wrap_text: '取消换行',
+	enable_clip_text: '截断文本',
+	disable_clip_text: '取消截断',
 	delete_field: '删除字段',
 
 	// Column types

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface ColumnSchema {
 	rollupFunction?: RollupFunction   // rollup: aggregation function
 	isHierarchical?: boolean          // self-relation used as hierarchy parent column
 	wrap?: boolean                    // table view: wrap long text cells onto multiple lines
+	clip?: boolean                    // table view: truncate at the cell boundary even when the view-wide wrap is on
 }
 
 // ── View / filter / sort ────────────────────────────────────────────────────

--- a/styles.css
+++ b/styles.css
@@ -1893,6 +1893,41 @@
 	height: auto;
 }
 
+/* Per-column clip (issue #45) — declared after the wrap rules on purpose:
+   same specificity, so source order lets clip win when the view-wide wrap is on */
+.nb-td--clip {
+	/* Sob table-layout auto, conteúdo nowrap alargaria a coluna (o "auto-fit"
+	   da issue). max-width: 0 tira o conteúdo do cálculo de largura e faz a
+	   célula respeitar a largura configurada, ativando o ellipsis.
+	   height: 1px permite que o .nb-td-inner use height: 100% e preencha a
+	   altura real da linha (que pode ser maior por causa de colunas com wrap),
+	   mantendo toda a célula clicável; age como mínimo, a célula ainda estica. */
+	max-width: 0;
+	height: 1px;
+}
+
+.nb-td--clip .nb-td-inner {
+	height: 100%;
+	max-height: none;
+	min-height: var(--nb-row-height);
+	overflow: hidden;
+	align-items: stretch;
+	padding: 0;
+}
+
+.nb-td--clip .nb-cell-text,
+.nb-td--clip .nb-cell-clickable {
+	white-space: nowrap;
+	word-break: normal;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	align-items: center;
+	height: 100%;
+	min-height: var(--nb-row-height);
+	padding-top: 0;
+	padding-bottom: 0;
+}
+
 /* ── Linha de agregação ─────────────────────────────────────────────────────── */
 
 .nb-tfoot {


### PR DESCRIPTION
## Summary

Adds a per-column **"Clip text"** option for text-like columns (text, title, url, email, phone). Clipped columns truncate at the cell boundary with an ellipsis and keep a fixed row height — even when the view-wide "Wrap text" toggle is on. The full value is available in a native hover tooltip.

## Details

- `clip?: boolean` on `ColumnSchema`; toggle lives in the column menu next to "Wrap text", and the two are mutually exclusive per column (enabling one clears the other)
- Clip CSS is declared after the wrap rules so source order resolves the override without `!important`
- `max-width: 0` on clipped cells: the table uses `table-layout: auto`, so nowrap content would otherwise auto-expand the column to the full text width (the exact "auto-fit makes columns too wide" complaint from the issue) — this removes the content from the width algorithm so the configured column width is honored and the ellipsis activates
- `height: 1px` on the td + `height: 100%` on the inner elements: when sibling wrapped columns make the row taller, the clipped cell's click/tooltip surface fills the full row height (and the editing input stays vertically centered) instead of covering only a 36px strip
- Text cells expose the full value via a native `title` tooltip
- Locale strings for all 7 languages

## Testing

- Validated end-to-end in Obsidian via CDP: menu toggle, truncation metrics (scrollWidth > clientWidth with the configured width honored), uniform row heights with view-wide wrap on, full-cell double-click opening the editor, tooltip content, mutual exclusion, and persistence across view switches and reopen
- Lint clean, 177 unit tests passing, production build ok

Closes #45
