### PR TITLE
feat: flexible column min width and optional clip ellipsis

### DIFF
--- a/src/components/DatabaseTable.tsx
+++ b/src/components/DatabaseTable.tsx
@@ -29,6 +29,7 @@ import { TFile, Notice } from 'obsidian'
 import React, { Fragment, ReactNode, useState, useMemo, useEffect, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useApp } from '../context'
+import { runtimePrefs } from '../runtime-prefs'
 import { DatabaseManager } from '../database-manager'
 import { ColumnSchema, ColumnType, ConditionalFormatRule, DatabaseConfig, FilterOperator, NoteRow, SortConfig, ViewConfig, AggregationType, DEFAULT_DATABASE_CONFIG, DEFAULT_VIEW } from '../types'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
@@ -547,7 +548,8 @@ function ResizeHandle({ onResize, onAutoFit }: { onResize: (w: number) => void; 
 		let currentWidth = startWidth
 
 		const onMouseMove = (ev: MouseEvent) => {
-			currentWidth = Math.max(50, startWidth + (ev.clientX - startX))
+			// 24px: mínimo para o resizer continuar clicável (issue #51)
+			currentWidth = Math.max(24, startWidth + (ev.clientX - startX))
 			th.style.width = currentWidth + 'px'
 		}
 		const onMouseUp = () => {
@@ -569,7 +571,7 @@ function ResizeHandle({ onResize, onAutoFit }: { onResize: (w: number) => void; 
 	)
 }
 
-function SortableTh({ id, size, children, stickyLeft, isLastPinned, isPinned, onTogglePin, sorted, onToggleSort, onResize, onAutoFit }: {
+function SortableTh({ id, size, children, stickyLeft, isLastPinned, isPinned, onTogglePin, sorted, onToggleSort, onResize, onAutoFit, userSized }: {
 	id: string
 	size: number
 	children: ReactNode
@@ -581,6 +583,7 @@ function SortableTh({ id, size, children, stickyLeft, isLastPinned, isPinned, on
 	onToggleSort?: () => void
 	onResize?: (width: number) => void
 	onAutoFit?: () => void
+	userSized?: boolean
 }) {
 	const {
 		attributes,
@@ -603,6 +606,7 @@ function SortableTh({ id, size, children, stickyLeft, isLastPinned, isPinned, on
 				isDragging ? 'nb-th--dragging' : '',
 				isSticky ? 'nb-th--sticky' : '',
 				isLastPinned ? 'nb-th--sticky-last' : '',
+				userSized ? 'nb-th--fixed' : '',
 			].filter(Boolean).join(' ')}
 			style={{
 				width: size,
@@ -2222,7 +2226,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 
 		{/* Tabela */}
 			<CellContext.Provider value={{ editingCell, setEditingCell, updateCell, schema: config.schema, relationOptions, updateSchema }}>
-			<div ref={tableWrapperRef} className={`nb-table-wrapper${activeView.wrapText ? ' nb-table--wrap' : ''}`}
+			<div ref={tableWrapperRef} className={`nb-table-wrapper${activeView.wrapText ? ' nb-table--wrap' : ''}${runtimePrefs.clipEllipsis ? '' : ' nb-clip-hard'}`}
 				style={{ '--nb-row-height': activeView.rowHeight === 'compact' ? '28px' : activeView.rowHeight === 'tall' ? '64px' : '36px' } as React.CSSProperties}>
 				<table ref={tableRef} className="nb-table">
 					<thead className="nb-thead">
@@ -2278,6 +2282,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 																'nb-th',
 																sticky ? 'nb-th--sticky' : '',
 																sticky?.isLast ? 'nb-th--sticky-last' : '',
+																activeView.columnWidths['_title'] !== undefined ? 'nb-th--fixed' : '',
 															].filter(Boolean).join(' ')}
 															style={{
 																width: header.getSize(),
@@ -2311,6 +2316,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 					onToggleSort={header.column.getCanSort() ? () => handleColumnToggleSort(header.id) : undefined}
 					onResize={w => { void handleColumnResize(header.id, w) }}
 					onAutoFit={() => { void handleColumnAutoFit(header.id) }}
+					userSized={activeView.columnWidths[header.id] !== undefined}
 													>
 														{flexRender(header.column.columnDef.header, header.getContext())}
 													</SortableTh>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -93,6 +93,8 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	edit_formula: 'Formel bearbeiten',
 	configure_lookup: 'Lookup konfigurieren',
 	configure_relation: 'Relation konfigurieren',
+	settings_clip_ellipsis_name: 'Auslassungspunkte beim Abschneiden von Text anzeigen',
+	settings_clip_ellipsis_desc: 'Wenn deaktiviert, schneiden abgeschnittene Zellen den Text am Zellenrand ohne Auslassungspunkte ab, wie in einer Tabellenkalkulation.',
 	format_number: 'Zahl formatieren',
 	format_date: 'Datum formatieren',
 	date_format_title: 'Datumsformat',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -91,6 +91,8 @@ const en = {
 	edit_formula: 'Edit formula',
 	configure_lookup: 'Configure lookup',
 	configure_relation: 'Configure relation',
+	settings_clip_ellipsis_name: 'Show ellipsis when clipping text',
+	settings_clip_ellipsis_desc: 'When off, clipped cells cut the text at the cell edge without the ellipsis character, spreadsheet-style.',
 	format_number: 'Format number',
 	format_date: 'Format date',
 	date_format_title: 'Date format',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -93,6 +93,8 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	edit_formula: 'Editar fórmula',
 	configure_lookup: 'Configurar lookup',
 	configure_relation: 'Configurar relación',
+	settings_clip_ellipsis_name: 'Mostrar puntos suspensivos al cortar el texto',
+	settings_clip_ellipsis_desc: 'Cuando está desactivado, las celdas cortadas interrumpen el texto en el borde de la celda sin el carácter de puntos suspensivos, al estilo de hoja de cálculo.',
 	format_number: 'Formatear número',
 	format_date: 'Formatear fecha',
 	date_format_title: 'Formato de fecha',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -93,6 +93,8 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	edit_formula: 'Modifier la formule',
 	configure_lookup: 'Configurer le lookup',
 	configure_relation: 'Configurer la relation',
+	settings_clip_ellipsis_name: 'Afficher les points de suspension lors de la troncature du texte',
+	settings_clip_ellipsis_desc: 'Lorsque cette option est désactivée, les cellules tronquées coupent le texte au bord de la cellule sans le caractère de points de suspension, comme dans un tableur.',
 	format_number: 'Formater le nombre',
 	format_date: 'Formater la date',
 	date_format_title: 'Format de date',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -93,6 +93,8 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	edit_formula: '数式を編集',
 	configure_lookup: 'Lookup を設定',
 	configure_relation: 'リレーションを設定',
+	settings_clip_ellipsis_name: 'テキストの切り詰め時に省略記号を表示',
+	settings_clip_ellipsis_desc: 'オフの場合、切り詰められたセルは省略記号を表示せず、スプレッドシートのようにセルの端でテキストを切り取ります。',
 	format_number: '数値の書式',
 	format_date: '日付の書式',
 	date_format_title: '日付の書式',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -93,6 +93,8 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	edit_formula: 'Editar fórmula',
 	configure_lookup: 'Configurar lookup',
 	configure_relation: 'Configurar relação',
+	settings_clip_ellipsis_name: 'Mostrar reticências ao cortar o texto',
+	settings_clip_ellipsis_desc: 'Quando desativado, as células cortadas interrompem o texto na borda da célula sem o caractere de reticências, no estilo de planilha.',
 	format_number: 'Formatar número',
 	format_date: 'Formatar data',
 	date_format_title: 'Formato de data',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -93,6 +93,8 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	edit_formula: '编辑公式',
 	configure_lookup: '配置 lookup',
 	configure_relation: '配置关联',
+	settings_clip_ellipsis_name: '截断文本时显示省略号',
+	settings_clip_ellipsis_desc: '关闭时，被截断的单元格会在单元格边缘直接截断文本，不显示省略号字符，类似电子表格的效果。',
 	format_number: '数字格式',
 	format_date: '日期格式',
 	date_format_title: '日期格式',

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { t } from './i18n'
 import { DATABASE_VIEW_TYPE, DatabaseView } from './database-view'
 import { DatabaseManager } from './database-manager'
 import { DEFAULT_SETTINGS, NotionBasesSettings, NotionBasesSettingTab } from './settings'
+import { runtimePrefs } from './runtime-prefs'
 import { DatabasePickerModal } from './database-picker-modal'
 import { QuickAddModal } from './quick-add-modal'
 import { registerDatabaseEmbed } from './database-embed'
@@ -149,6 +150,7 @@ export default class NotionBasesPlugin extends Plugin {
 			DEFAULT_SETTINGS,
 			(await this.loadData()) as Partial<NotionBasesSettings>
 		)
+		runtimePrefs.clipEllipsis = this.settings.clipEllipsis
 	}
 
 	async saveSettings() {

--- a/src/runtime-prefs.ts
+++ b/src/runtime-prefs.ts
@@ -1,0 +1,8 @@
+/**
+ * Preferências de plugin lidas pelos componentes React em tempo de render.
+ * O plugin (main.ts) mantém este objeto sincronizado com NotionBasesSettings —
+ * evita atravessar props/contexto para configurações globais de exibição.
+ */
+export const runtimePrefs = {
+	clipEllipsis: true,
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { App, PluginSettingTab, Setting } from 'obsidian'
 import NotionBasesPlugin from './main'
 import { ViewConfig } from './types'
+import { runtimePrefs } from './runtime-prefs'
 import { t } from './i18n'
 
 export interface NotionBasesSettings {
@@ -9,6 +10,7 @@ export interface NotionBasesSettings {
 	embedViews: Record<string, ViewConfig>
 	readInlineFields: boolean
 	pageSize: number
+	clipEllipsis: boolean
 }
 
 export const DEFAULT_SETTINGS: NotionBasesSettings = {
@@ -17,6 +19,7 @@ export const DEFAULT_SETTINGS: NotionBasesSettings = {
 	embedViews: {},
 	readInlineFields: false,
 	pageSize: 0,
+	clipEllipsis: true,
 }
 
 export class NotionBasesSettingTab extends PluginSettingTab {
@@ -53,6 +56,19 @@ export class NotionBasesSettingTab extends PluginSettingTab {
 					.onChange(async value => {
 						this.plugin.settings.readInlineFields = value
 						this.plugin.manager.readInlineFields = value
+						await this.plugin.saveSettings()
+					})
+			)
+
+		new Setting(containerEl)
+			.setName(t('settings_clip_ellipsis_name'))
+			.setDesc(t('settings_clip_ellipsis_desc'))
+			.addToggle(toggle =>
+				toggle
+					.setValue(this.plugin.settings.clipEllipsis)
+					.onChange(async value => {
+						this.plugin.settings.clipEllipsis = value
+						runtimePrefs.clipEllipsis = value
 						await this.plugin.saveSettings()
 					})
 			)

--- a/styles.css
+++ b/styles.css
@@ -1928,6 +1928,34 @@
 	padding-bottom: 0;
 }
 
+/* Ellipsis opcional (issue #51) — classe aplicada ao wrapper quando a
+   configuração "Show ellipsis when clipping text" está desligada */
+.nb-clip-hard .nb-td--clip .nb-cell-text,
+.nb-clip-hard .nb-td--clip .nb-cell-clickable {
+	text-overflow: clip;
+}
+
+/* Cabeçalho estreitável (issue #51): somente colunas com largura definida
+   pelo usuário param de impor min-content — o nome trunca quando faltar
+   espaço. Colunas nunca redimensionadas mantêm o auto-ajuste de sempre. */
+.nb-th--fixed {
+	max-width: 0;
+}
+
+.nb-th--fixed .nb-header-label {
+	min-width: 0;
+	overflow: hidden;
+}
+
+.nb-th--fixed .nb-header-name {
+	min-width: 0;
+	white-space: nowrap;
+}
+
+.nb-th--fixed .nb-th-inner-title > div {
+	min-width: 0;
+}
+
 /* ── Linha de agregação ─────────────────────────────────────────────────────── */
 
 .nb-tfoot {


### PR DESCRIPTION
## Summary

Follow-up refinements to the clip feature (#45), requested by the original author after 1.9.0 shipped: an option to drop the ellipsis on clipped cells, and genuinely narrow columns.

## Details

**Optional ellipsis**
- New plugin setting **"Show ellipsis when clipping text"** (default on). When off, clipped cells hard-cut at the cell edge, spreadsheet-style
- Implemented via a small `runtime-prefs` module kept in sync by the plugin (`loadSettings` + the settings toggle); `DatabaseTable` reads it at render time and applies an `nb-clip-hard` class on the table wrapper

**Flexible column minimum width**
- Resize drag minimum lowered from 50px to 24px (enough to keep the resizer usable)
- Columns explicitly resized by the user (present in `columnWidths`) get `nb-th--fixed`: `max-width: 0` removes the header from the width algorithm, and the heading name truncates when space runs out — previously the header's min-content (drag handle + icon + name + sort) silently imposed a ~100px floor regardless of the drag clamp
- Columns never resized keep the current auto-sizing behavior — deliberate, so no existing layout changes

## Testing

- Validated end-to-end in Obsidian via CDP: with the setting off, computed `text-overflow: clip` and visibly hard-cut cells; a column configured at 40px measured exactly 40px (header truncated to the type icon) once the table overflows horizontally — table-stretch when narrower than the view is pre-existing behavior and unchanged
- Lint clean, 182 unit tests passing, production build ok
- Setting restored to default after validation

Closes #51
