### PR TITLE
feat: collapsible groups in the table, list and gallery views

### DIFF
--- a/src/components/DatabaseBoard.tsx
+++ b/src/components/DatabaseBoard.tsx
@@ -3,13 +3,14 @@ import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } fr
 import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
 import {
-	ColumnSchema, FilterOperator, NoteRow, SelectOption, ViewConfig,
+	ColumnSchema, FilterOperator, NoteRow, ViewConfig,
 } from '../types'
 import {
 	ActiveFilter, applyFilters, applySorts,
 	getColumnIconStatic, getDefaultOperator,
 	getCardConditionalStyle,
 } from './filter-utils'
+import { buildGroups, getGroupableColumns } from './group-utils'
 import { FilterPillsRow } from './FilterPillsRow'
 import { t } from '../i18n'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -199,7 +200,7 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 	// ── Groupable columns ─────────────────────────────────────────────────────
 
 	const groupableColumns = useMemo(
-		() => config.schema.filter(c => c.type === 'select' || c.type === 'status'),
+		() => getGroupableColumns(config.schema),
 		[config.schema]
 	)
 
@@ -224,46 +225,13 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 		[config.schema, activeView.hiddenColumns, groupByCol]
 	)
 
-	const DEFAULT_STATUS_OPTIONS: SelectOption[] = [
-		{ value: t('status_not_started'), color: '#9E9E9E' },
-		{ value: t('status_in_progress'), color: '#2196F3' },
-		{ value: t('status_done'), color: '#4CAF50' },
-		{ value: t('status_cancelled'), color: '#F44336' },
-	]
-
 	const columns = useMemo(() => {
 		if (!groupByCol) return []
-		const options = (groupByCol.type === 'status' && !groupByCol.options?.length)
-			? DEFAULT_STATUS_OPTIONS
-			: (groupByCol.options ?? [])
-		const all = [
-			...options.map(opt => ({
-				value: opt.value,
-				label: opt.value,
-				color: opt.color,
-				rows: sortedRows.filter(r => r[groupByCol.id] === opt.value),
-			})),
-			{
-				value: '',
-				label: t('no_value'),
-				color: undefined,
-				rows: sortedRows.filter(r => {
-					const v = r[groupByCol.id]
-					return v === null || v === undefined || stringifyScalar(v).trim() === ''
-				}),
-			},
-		]
-		// Apply saved column order
-		const order = activeView.boardColumnOrder
-		let ordered = all
-		if (order && order.length > 0) {
-			const inOrder = order.flatMap(v => { const c = all.find(x => x.value === v); return c ? [c] : [] })
-			const rest = all.filter(x => !order.includes(x.value))
-			ordered = [...inOrder, ...rest]
-		}
-		let result = hideEmpty ? ordered.filter(c => c.rows.length > 0) : ordered
-		if (hideNoValue) result = result.filter(c => c.value !== '')
-		return result
+		return buildGroups(sortedRows, r => r[groupByCol.id], groupByCol, {
+			order: activeView.boardColumnOrder,
+			hideEmpty,
+			hideNoValue,
+		}).map(g => ({ value: g.value, label: g.label, color: g.color, rows: g.items }))
 	}, [groupByCol, sortedRows, hideEmpty, hideNoValue, activeView.boardColumnOrder])
 
 	// ── Actions ───────────────────────────────────────────────────────────────

--- a/src/components/DatabaseGallery.tsx
+++ b/src/components/DatabaseGallery.tsx
@@ -12,6 +12,7 @@ import {
 	getCardConditionalStyle,
 } from './filter-utils'
 import { FilterPillsRow } from './FilterPillsRow'
+import { GroupHeader, GroupByMenu } from './GroupHeader'
 import { t } from '../i18n'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
@@ -19,9 +20,14 @@ import { useDebouncedValue } from '../hooks/useDebouncedValue'
 import { MobileToolbar, IconFields, IconSort, IconFilter, IconSubfolders } from './MobileToolbar'
 import { Pagination } from './Pagination'
 import { usePagination } from '../hooks/usePagination'
+import { useGrouping } from '../hooks/useGrouping'
 import { BottomSheet } from './BottomSheet'
 import { ConditionalFormatPanel } from './ConditionalFormatPanel'
 import { stringifyScalar } from '../value-utils'
+
+
+/** Stable identity so the grouping memo is not invalidated on every render. */
+const readRowValue = (row: NoteRow, columnId: string): unknown => row[columnId]
 
 interface DatabaseGalleryProps {
 	dbFile: TFile | null
@@ -187,6 +193,7 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 	const [sortPanelOpen, setSortPanelOpen] = useState(false)
 	const [sortAnchorRect, setSortAnchorRect] = useState<DOMRect | null>(null)
 	const [cfPanelOpen, setCfPanelOpen] = useState(false)
+	const [groupByMenuOpen, setGroupByMenuOpen] = useState(false)
 
 	const filterMenuRef = useRef<HTMLDivElement>(null)
 	const fieldsMenuRef = useRef<HTMLDivElement>(null)
@@ -196,6 +203,7 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 	const sortButtonRef = useRef<HTMLButtonElement>(null)
 	const mobileActionBarRef = useRef<HTMLDivElement>(null)
 	const cfPanelRef = useRef<HTMLDivElement>(null)
+	const groupByMenuRef = useRef<HTMLDivElement>(null)
 
 	useEffect(() => { setActiveView(externalView) }, [externalView.id])
 
@@ -242,6 +250,15 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 	}, [coverMenuOpen])
 
 	useEffect(() => {
+		if (!groupByMenuOpen) return
+		const h = (e: MouseEvent) => {
+			if (mobileActionBarRef.current?.contains(e.target as Node)) return
+			if (groupByMenuRef.current && !groupByMenuRef.current.contains(e.target as Node)) setGroupByMenuOpen(false)
+		}
+		activeDocument.addEventListener('mousedown', h); return () => activeDocument.removeEventListener('mousedown', h)
+	}, [groupByMenuOpen])
+
+	useEffect(() => {
 		if (!sizeMenuOpen) return
 		const h = (e: MouseEvent) => {
 			if (mobileActionBarRef.current?.contains(e.target as Node)) return
@@ -265,7 +282,14 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 	const debouncedFilters = useDebouncedValue(activeFilters, 200)
 	const filteredRows = useMemo(() => applyFilters(rows, debouncedFilters), [rows, debouncedFilters])
 	const displayRows = useMemo(() => applySorts(filteredRows, activeView.sorts), [filteredRows, activeView.sorts])
-	const { pageItems: pagedRows, currentPage, totalPages, setPage } = usePagination(displayRows, manager.pageSize)
+
+	// ── Grouping ──────────────────────────────────────────────────────────────
+
+	const { groupableColumns, groupByCol, groups, collapsedGroups, toggleGroup, collapseAll, expandAll } =
+		useGrouping(config.schema, activeView, displayRows, readRowValue)
+
+	// Grouping renders every row inside its group, so pagination is turned off
+	const { pageItems: pagedRows, currentPage, totalPages, setPage } = usePagination(displayRows, groupByCol ? 0 : manager.pageSize)
 
 	const visibleCols = useMemo(
 		() => config.schema.filter(col => col.visible && !activeView.hiddenColumns.includes(col.id)),
@@ -308,6 +332,11 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 
 	const handleAddRow = async () => { if (dbFile) await manager.createNoteWithTemplate(dbFile) }
 
+	const handleAddRowToGroup = async (groupValue: string) => {
+		if (!dbFile || !groupByCol) return
+		await manager.createNoteWithTemplate(dbFile, groupValue ? { [groupByCol.id]: groupValue } : undefined)
+	}
+
 	// ── Render ───────────────────────────────────────────────────────────────
 
 	const isMobile = useIsMobile()
@@ -322,6 +351,19 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 		if (except !== 'cover') setCoverMenuOpen(false)
 		if (except !== 'filter') setFilterMenuOpen(false)
 		if (except !== 'sort') setSortPanelOpen(false)
+		if (except !== 'groupby') setGroupByMenuOpen(false)
+	}
+
+	const groupByMenuProps = {
+		groupableColumns,
+		activeColumnId: activeView.groupByColumnId,
+		hideEmpty: activeView.boardHideEmpty ?? false,
+		hideNoValue: activeView.boardHideNoValue ?? false,
+		onSelect: (id: string | undefined) => { void saveView({ ...activeView, groupByColumnId: id }); setGroupByMenuOpen(false) },
+		onToggleHideEmpty: (next: boolean) => { void saveView({ ...activeView, boardHideEmpty: next }) },
+		onToggleHideNoValue: (next: boolean) => { void saveView({ ...activeView, boardHideNoValue: next }) },
+		onCollapseAll: collapseAll,
+		onExpandAll: expandAll,
 	}
 
 	const toolbarContent = isMobile ? (
@@ -330,6 +372,7 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 			actions={[
 				{ id: 'fields', label: t('fields'), icon: <IconFields />, active: fieldsMenuOpen, onClick: () => { closeMobileMenus('fields'); setFieldsMenuOpen(v => !v) } },
 				{ id: 'cover', label: t('cover'), icon: <IconFields />, active: coverMenuOpen, onClick: () => { closeMobileMenus('cover'); setCoverMenuOpen(v => !v) } },
+				...(groupableColumns.length > 0 ? [{ id: 'groupby', label: t('group_by'), icon: <IconSort />, active: groupByMenuOpen, onClick: () => { closeMobileMenus('groupby'); setGroupByMenuOpen(v => !v) } }] : []),
 				{ id: 'subfolders', label: t('tooltip_include_subfolders'), icon: <IconSubfolders />, active: !!activeView.includeSubfolders, onClick: () => { closeMobileMenus(); void saveView({ ...activeView, includeSubfolders: !activeView.includeSubfolders }) } },
 				{ id: 'sort', label: t('sort'), icon: <IconSort />, active: activeView.sorts.length > 0, badge: activeView.sorts.length || undefined, onClick: () => { closeMobileMenus('sort'); if (!sortPanelOpen && sortButtonRef.current) setSortAnchorRect(sortButtonRef.current.getBoundingClientRect()); setSortPanelOpen(v => !v) } },
 				{ id: 'filter', label: t('filter'), icon: <IconFilter />, active: filterMenuOpen, badge: activeFilters.length || undefined, onClick: () => { closeMobileMenus('filter'); setFilterMenuOpen(v => !v) } },
@@ -349,6 +392,9 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 						<span className="nb-field-name">{col.name}</span>
 					</label>
 				))}
+			</BottomSheet>
+			<BottomSheet open={groupByMenuOpen} onClose={() => setGroupByMenuOpen(false)} title={t('group_by')}>
+				<GroupByMenu {...groupByMenuProps} />
 			</BottomSheet>
 			<BottomSheet open={coverMenuOpen} onClose={() => setCoverMenuOpen(false)} title={t('cover')}>
 				<button
@@ -448,6 +494,16 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 						</div>
 					)}
 				</div>
+
+				{/* Agrupar por */}
+				{groupableColumns.length > 0 && (
+					<div className="nb-fields-menu-wrapper" ref={groupByMenuRef}>
+						<button className={`nb-toolbar-btn${groupByMenuOpen ? ' nb-toolbar-btn--active' : ''}`} onClick={() => setGroupByMenuOpen(v => !v)}>
+							{t('group_by')}: <strong>{groupByCol?.name ?? t('group_none')}</strong>
+						</button>
+						{groupByMenuOpen && <GroupByMenu {...groupByMenuProps} />}
+					</div>
+				)}
 
 				{/* Capa */}
 				<div className="nb-fields-menu-wrapper" ref={coverMenuRef}>
@@ -599,28 +655,41 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 		</>
 	)
 
+	const renderCard = (row: NoteRow) => (
+		<GalleryCard
+			key={row._file.path}
+			row={row}
+			cardSize={cardSize}
+			coverField={coverField}
+			visibleCols={visibleCols}
+			dbFolderPath={dbFolderPath}
+			includeSubfolders={activeView.includeSubfolders ?? false}
+			onOpen={openFile}
+			cardStyle={activeView.conditionalFormats?.length ? getCardConditionalStyle(row, activeView.conditionalFormats, config.schema) : undefined}
+		/>
+	)
+
 	return (
 		<div className="nb-container">
 			{toolbarContent}
 
 			{/* Gallery grid */}
 			<div className="nb-gallery" style={{ gridTemplateColumns: gridTemplate }}>
-				{pagedRows.map(row => {
-					const cfStyle = activeView.conditionalFormats?.length ? getCardConditionalStyle(row, activeView.conditionalFormats, config.schema) : undefined
-					return (
-						<GalleryCard
-							key={row._file.path}
-							row={row}
-							cardSize={cardSize}
-							coverField={coverField}
-							visibleCols={visibleCols}
-							dbFolderPath={dbFolderPath}
-							includeSubfolders={activeView.includeSubfolders ?? false}
-							onOpen={openFile}
-							cardStyle={cfStyle}
-						/>
-					)
-				})}
+				{groups ? groups.map(group => (
+					<React.Fragment key={group.value}>
+						<div className="nb-gallery-group">
+							<GroupHeader
+								label={group.label}
+								color={group.color}
+								count={group.items.length}
+								collapsed={collapsedGroups.has(group.value)}
+								onToggle={() => toggleGroup(group.value)}
+								onAdd={() => { void handleAddRowToGroup(group.value) }}
+							/>
+						</div>
+						{!collapsedGroups.has(group.value) && group.items.map(renderCard)}
+					</React.Fragment>
+				)) : pagedRows.map(renderCard)}
 
 				{/* Add card */}
 				<div className="nb-gallery-card nb-gallery-card--add" onClick={() => { void handleAddRow() }}>

--- a/src/components/DatabaseList.tsx
+++ b/src/components/DatabaseList.tsx
@@ -12,6 +12,7 @@ import {
 	getCardConditionalStyle,
 } from './filter-utils'
 import { FilterPillsRow } from './FilterPillsRow'
+import { GroupHeader, GroupByMenu } from './GroupHeader'
 import { t } from '../i18n'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
@@ -19,10 +20,15 @@ import { useDebouncedValue } from '../hooks/useDebouncedValue'
 import { MobileToolbar, IconFields, IconSort, IconFilter, IconSubfolders } from './MobileToolbar'
 import { Pagination } from './Pagination'
 import { usePagination } from '../hooks/usePagination'
+import { useGrouping } from '../hooks/useGrouping'
 import { BottomSheet } from './BottomSheet'
 import { ConditionalFormatPanel } from './ConditionalFormatPanel'
 import { findHierarchyColumn, buildHierarchyTree, HierarchyRow } from '../hierarchy-utils'
 import { stringifyScalar } from '../value-utils'
+
+
+/** Stable identity so the grouping memo is not invalidated on every render. */
+const readRowValue = (row: NoteRow, columnId: string): unknown => row[columnId]
 
 interface DatabaseListProps {
 	dbFile: TFile | null
@@ -178,8 +184,10 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 	const [sortPanelOpen, setSortPanelOpen] = useState(false)
 	const [sortAnchorRect, setSortAnchorRect] = useState<DOMRect | null>(null)
 	const [cfPanelOpen, setCfPanelOpen] = useState(false)
+	const [groupByMenuOpen, setGroupByMenuOpen] = useState(false)
 	const filterMenuRef = useRef<HTMLDivElement>(null)
 	const fieldsMenuRef = useRef<HTMLDivElement>(null)
+	const groupByMenuRef = useRef<HTMLDivElement>(null)
 	const sortPanelRef = useRef<HTMLDivElement>(null)
 	const sortButtonRef = useRef<HTMLButtonElement>(null)
 	const mobileActionBarRef = useRef<HTMLDivElement>(null)
@@ -230,6 +238,15 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 		activeDocument.addEventListener('mousedown', h); return () => activeDocument.removeEventListener('mousedown', h)
 	}, [sortPanelOpen])
 
+	useEffect(() => {
+		if (!groupByMenuOpen) return
+		const h = (e: MouseEvent) => {
+			if (mobileActionBarRef.current?.contains(e.target as Node)) return
+			if (groupByMenuRef.current && !groupByMenuRef.current.contains(e.target as Node)) setGroupByMenuOpen(false)
+		}
+		activeDocument.addEventListener('mousedown', h); return () => activeDocument.removeEventListener('mousedown', h)
+	}, [groupByMenuOpen])
+
 	// ── Filter actions ───────────────────────────────────────────────────────
 
 	const saveActivePills = useCallback(async (filters: ActiveFilter[]) => {
@@ -257,6 +274,11 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 	}, [activeView, saveView])
 
 	const handleAddRow = async () => { if (dbFile) await manager.createNoteWithTemplate(dbFile) }
+
+	const handleAddRowToGroup = async (groupValue: string) => {
+		if (!dbFile || !groupByCol) return
+		await manager.createNoteWithTemplate(dbFile, groupValue ? { [groupByCol.id]: groupValue } : undefined)
+	}
 
 	// ── Hierarchy state ───────────────────────────────────────────────────────
 
@@ -288,7 +310,13 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 		return buildHierarchyTree(displayRows, hierarchyCol.id, activeView.sorts, hExpandedSet, hAllExpanded)
 	}, [displayRows, hierarchyCol, activeView.sorts, hExpandedSet, hAllExpanded])
 
-	const { pageItems: pagedRows, currentPage, totalPages, setPage } = usePagination(displayRows, hierarchyCol ? 0 : manager.pageSize)
+	// ── Grouping ──────────────────────────────────────────────────────────────
+
+	const { groupableColumns, groupByCol, groups, collapsedGroups, toggleGroup, collapseAll, expandAll } =
+		useGrouping(config.schema, activeView, displayRows, readRowValue)
+
+	// Grouping renders every row inside its group, so pagination is turned off
+	const { pageItems: pagedRows, currentPage, totalPages, setPage } = usePagination(displayRows, (hierarchyCol || groupByCol) ? 0 : manager.pageSize)
 
 	const visibleCols = useMemo(() =>
 		config.schema.filter(col => col.visible && !activeView.hiddenColumns.includes(col.id)),
@@ -312,6 +340,19 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 		if (except !== 'fields') setFieldsMenuOpen(false)
 		if (except !== 'filter') setFilterMenuOpen(false)
 		if (except !== 'sort') setSortPanelOpen(false)
+		if (except !== 'groupby') setGroupByMenuOpen(false)
+	}
+
+	const groupByMenuProps = {
+		groupableColumns,
+		activeColumnId: activeView.groupByColumnId,
+		hideEmpty: activeView.boardHideEmpty ?? false,
+		hideNoValue: activeView.boardHideNoValue ?? false,
+		onSelect: (id: string | undefined) => { void saveView({ ...activeView, groupByColumnId: id }); setGroupByMenuOpen(false) },
+		onToggleHideEmpty: (next: boolean) => { void saveView({ ...activeView, boardHideEmpty: next }) },
+		onToggleHideNoValue: (next: boolean) => { void saveView({ ...activeView, boardHideNoValue: next }) },
+		onCollapseAll: collapseAll,
+		onExpandAll: expandAll,
 	}
 
 	const toolbarContent = isMobile ? (
@@ -319,6 +360,7 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 			actionBarRef={mobileActionBarRef}
 			actions={[
 				{ id: 'fields', label: t('fields'), icon: <IconFields />, active: fieldsMenuOpen, onClick: () => { closeMobileMenus('fields'); setFieldsMenuOpen(v => !v) } },
+				...(groupableColumns.length > 0 ? [{ id: 'groupby', label: t('group_by'), icon: <IconSort />, active: groupByMenuOpen, onClick: () => { closeMobileMenus('groupby'); setGroupByMenuOpen(v => !v) } }] : []),
 				{ id: 'subfolders', label: t('tooltip_include_subfolders'), icon: <IconSubfolders />, active: !!activeView.includeSubfolders, onClick: () => { closeMobileMenus(); void saveView({ ...activeView, includeSubfolders: !activeView.includeSubfolders }) } },
 				{ id: 'sort', label: t('sort'), icon: <IconSort />, active: activeView.sorts.length > 0, badge: activeView.sorts.length || undefined, onClick: () => { closeMobileMenus('sort'); if (!sortPanelOpen && sortButtonRef.current) setSortAnchorRect(sortButtonRef.current.getBoundingClientRect()); setSortPanelOpen(v => !v) } },
 				{ id: 'filter', label: t('filter'), icon: <IconFilter />, active: filterMenuOpen, badge: activeFilters.length || undefined, onClick: () => { closeMobileMenus('filter'); setFilterMenuOpen(v => !v) } },
@@ -338,6 +380,9 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 						<span className="nb-field-name">{col.name}</span>
 					</label>
 				))}
+			</BottomSheet>
+			<BottomSheet open={groupByMenuOpen} onClose={() => setGroupByMenuOpen(false)} title={t('group_by')}>
+				<GroupByMenu {...groupByMenuProps} />
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
 				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), '📄', 'title')}>
@@ -417,6 +462,14 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 						</div>
 					)}
 				</div>
+				{groupableColumns.length > 0 && (
+					<div className="nb-fields-menu-wrapper" ref={groupByMenuRef}>
+						<button className={`nb-toolbar-btn${groupByMenuOpen ? ' nb-toolbar-btn--active' : ''}`} onClick={() => setGroupByMenuOpen(v => !v)}>
+							{t('group_by')}: <strong>{groupByCol?.name ?? t('group_none')}</strong>
+						</button>
+						{groupByMenuOpen && <GroupByMenu {...groupByMenuProps} />}
+					</div>
+				)}
 				<button
 					className={`nb-toolbar-btn nb-toolbar-btn--icon nb-subfolder-toggle ${activeView.includeSubfolders ? 'nb-toolbar-btn--active' : ''}`}
 					onClick={() => { void saveView({ ...activeView, includeSubfolders: !activeView.includeSubfolders }) }}
@@ -493,35 +546,49 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 		</>
 	)
 
+	const renderRow = (row: NoteRow, depth: number, hasChildren: boolean) => (
+		<ListRow
+			key={row._file.path}
+			row={row}
+			depth={depth}
+			hasChildren={hasChildren}
+			isExpanded={hAllExpanded ? !hExpandedSet.has(row._file.path) : hExpandedSet.has(row._file.path)}
+			isHierarchical={hierarchicalRows !== null && !groupByCol}
+			visibleCols={visibleCols}
+			dbFolderPath={dbFolderPath}
+			includeSubfolders={activeView.includeSubfolders ?? false}
+			onOpen={openFile}
+			onToggleExpand={toggleHExpand}
+			isMobile={isMobile}
+			onLongPress={handleLongPress}
+			onContextMenu={handleContextMenu}
+			longPressRef={longPressRef}
+			cardStyle={activeView.conditionalFormats?.length ? getCardConditionalStyle(row, activeView.conditionalFormats, config.schema) : undefined}
+		/>
+	)
+
 	return (
 		<div className="nb-container">
 			{toolbarContent}
 
 			{/* List */}
 			<div className="nb-list">
-				{(hierarchicalRows ?? pagedRows.map(r => ({ row: r, depth: 0, hasChildren: false, parentTitle: null }))).map(({ row, depth, hasChildren }) => {
-					const isExp = hAllExpanded ? !hExpandedSet.has(row._file.path) : hExpandedSet.has(row._file.path)
-					return (
-						<ListRow
-							key={row._file.path}
-							row={row}
-							depth={depth}
-							hasChildren={hasChildren}
-							isExpanded={isExp}
-							isHierarchical={hierarchicalRows !== null}
-							visibleCols={visibleCols}
-							dbFolderPath={dbFolderPath}
-							includeSubfolders={activeView.includeSubfolders ?? false}
-							onOpen={openFile}
-							onToggleExpand={toggleHExpand}
-							isMobile={isMobile}
-							onLongPress={handleLongPress}
-							onContextMenu={handleContextMenu}
-							longPressRef={longPressRef}
-							cardStyle={activeView.conditionalFormats?.length ? getCardConditionalStyle(row, activeView.conditionalFormats, config.schema) : undefined}
+				{groups ? groups.map(group => (
+					<React.Fragment key={group.value}>
+						<GroupHeader
+							label={group.label}
+							color={group.color}
+							count={group.items.length}
+							collapsed={collapsedGroups.has(group.value)}
+							onToggle={() => toggleGroup(group.value)}
+							onAdd={() => { void handleAddRowToGroup(group.value) }}
 						/>
-					)
-				})}
+						{!collapsedGroups.has(group.value) && group.items.map(row => renderRow(row, 0, false))}
+					</React.Fragment>
+				)) : (
+					(hierarchicalRows ?? pagedRows.map(r => ({ row: r, depth: 0, hasChildren: false, parentTitle: null })))
+						.map(({ row, depth, hasChildren }) => renderRow(row, depth, hasChildren))
+				)}
 				<button className="nb-add-row nb-list-add-row" onClick={() => { void handleAddRow() }}>
 					{'+ ' + t('add_entry')}
 				</button>

--- a/src/components/DatabaseTable.tsx
+++ b/src/components/DatabaseTable.tsx
@@ -47,7 +47,10 @@ import { ConditionalFormatPanel } from './ConditionalFormatPanel'
 import { Pagination } from './Pagination'
 import { useSaveTracker } from '../hooks/useSaveTracker'
 import { usePagination } from '../hooks/usePagination'
+import { useGrouping } from '../hooks/useGrouping'
 import { findHierarchyColumn, buildHierarchyTree, HierarchyRow } from '../hierarchy-utils'
+import { getGroupableColumns } from './group-utils'
+import { GroupHeader, GroupByMenu } from './GroupHeader'
 import { stringifyScalar } from '../value-utils'
 
 // ── Virtual row rendering (separate component to isolate hooks) ──────────
@@ -107,17 +110,33 @@ interface VirtualTbodyProps {
 	conditionalFormats?: ConditionalFormatRule[]
 	schema?: ColumnSchema[]
 	disableVirtual?: boolean
+	groupHeader?: {
+		label: string
+		color?: string
+		count: number
+		collapsed: boolean
+		onToggle: () => void
+		onAdd: () => void
+	}
 }
 
-function VirtualTbody({ scrollRef, rowHeight, rows, stickyMap, isMobile, setEditingCell, setContextMenuFile, longPressRef, columns, onAddRow, hierarchyMap, onToggleExpand, onAddSubRow, expandedSet, allExpanded, rowDragEnabled, dragOverPath, onRowDragStart, onRowDragOver, onRowDragEnd, onRowDrop, conditionalFormats, schema, disableVirtual }: VirtualTbodyProps) {
+function VirtualTbody({ scrollRef, rowHeight, rows, stickyMap, isMobile, setEditingCell, setContextMenuFile, longPressRef, columns, onAddRow, hierarchyMap, onToggleExpand, onAddSubRow, expandedSet, allExpanded, rowDragEnabled, dragOverPath, onRowDragStart, onRowDragOver, onRowDragEnd, onRowDrop, conditionalFormats, schema, disableVirtual, groupHeader }: VirtualTbodyProps) {
 	const { startIdx, endIdx, topPad } = useVirtualScroll(scrollRef, rowHeight, disableVirtual)
 	const visibleRows = rows.slice(startIdx, Math.min(rows.length, endIdx))
 	const bottomPad = Math.max(0, (rows.length - Math.min(rows.length, endIdx)) * rowHeight)
 
 	return (
 		<tbody className="nb-tbody">
+			{groupHeader && (
+				<tr className="nb-group-header-row">
+					<td className="nb-group-header-td" colSpan={(columns).length + 1}>
+						<GroupHeader {...groupHeader} />
+					</td>
+				</tr>
+			)}
+			{groupHeader?.collapsed ? null : <>
 			{rows.length === 0 ? (
-				<tr><td colSpan={(columns).length + 1} className="nb-empty-rows">{t('no_results')}</td></tr>
+				groupHeader ? null : <tr><td colSpan={(columns).length + 1} className="nb-empty-rows">{t('no_results')}</td></tr>
 			) : (
 				<>
 					{topPad > 0 && <tr style={{ height: topPad }} />}
@@ -200,9 +219,13 @@ function VirtualTbody({ scrollRef, rowHeight, rows, stickyMap, isMobile, setEdit
 					<button className="nb-add-row-btn" onClick={onAddRow}>{'+ ' + t('add_row')}</button>
 				</td>
 			</tr>
+			</>}
 		</tbody>
 	)
 }
+
+/** Stable identity so the grouping memo is not invalidated on every render. */
+const readTableRowValue = (row: { original: NoteRow }, columnId: string): unknown => row.original[columnId]
 
 // ── Validação de compatibilidade de tipos ────────────────────────────────────
 
@@ -790,6 +813,8 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 	const [editingCell, setEditingCell] = useState<{ rowIndex: number; columnId: string } | null>(null)
 	const [fieldsMenuOpen, setFieldsMenuOpen] = useState(false)
 	const fieldsMenuRef = useRef<HTMLDivElement>(null)
+	const [groupByMenuOpen, setGroupByMenuOpen] = useState(false)
+	const groupByMenuRef = useRef<HTMLDivElement>(null)
 	const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
 	const [actionsMenuOpen, setActionsMenuOpen] = useState(false)
 	const [contextMenuFile, setContextMenuFile] = useState<TFile | null>(null)
@@ -1138,6 +1163,15 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 		[config.schema, dbFile?.path],
 	)
 
+	// ── Grouping ──────────────────────────────────────────────────────────────
+	// Groups are built from the TanStack rows further down, once they exist.
+
+	const groupableColumns = useMemo(() => getGroupableColumns(config.schema), [config.schema])
+	const groupByCol = useMemo(
+		() => config.schema.find(c => c.id === activeView.groupByColumnId) ?? null,
+		[config.schema, activeView.groupByColumnId],
+	)
+
 	const hierarchicalRows = useMemo(() => {
 		if (!hierarchyCol) return null
 		return buildHierarchyTree(filteredRows, hierarchyCol.id, activeView.sorts, hierarchyExpandedSet, hierarchyAllExpanded)
@@ -1158,8 +1192,10 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 		return map
 	}, [hierarchicalRows])
 
+	// Grouping renders every row inside its group, so pagination is turned off
+	const effectivePageSize = groupByCol ? 0 : manager.pageSize
 	// When paginated, apply globalFilter before slicing so pagination knows the real count
-	const isPaginated = manager.pageSize > 0
+	const isPaginated = effectivePageSize > 0
 	const searchFilteredData = useMemo(() => {
 		if (!isPaginated || !debouncedGlobalFilter) return tableData
 		const q = debouncedGlobalFilter.toLowerCase()
@@ -1174,7 +1210,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 		)
 	}, [tableData, debouncedGlobalFilter, isPaginated])
 
-	const { pageItems: pagedData, currentPage, totalPages, setPage } = usePagination(searchFilteredData, manager.pageSize)
+	const { pageItems: pagedData, currentPage, totalPages, setPage } = usePagination(searchFilteredData, effectivePageSize)
 
 	filteredRowsRef.current = pagedData
 
@@ -1248,6 +1284,12 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 		lastCreatedPath.current = newFile.path
 	}, [dbFile, hierarchyCol, manager])
 
+	const handleAddRowToGroup = useCallback(async (groupValue: string) => {
+		if (!dbFile || !groupByCol) return
+		const newFile = await manager.createNoteWithTemplate(dbFile, groupValue ? { [groupByCol.id]: groupValue } : undefined)
+		lastCreatedPath.current = newFile.path
+	}, [dbFile, groupByCol, manager])
+
 	const toggleHierarchyExpand = useCallback((filePath: string) => {
 		setHierarchyExpandedSet(prev => {
 			const next = new Set(prev)
@@ -1270,6 +1312,18 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 		activeDocument.addEventListener('mousedown', handler)
 		return () => activeDocument.removeEventListener('mousedown', handler)
 	}, [fieldsMenuOpen])
+
+	useEffect(() => {
+		if (!groupByMenuOpen) return
+		const handler = (e: MouseEvent) => {
+			if (mobileActionBarRef.current?.contains(e.target as Node)) return
+			if (groupByMenuRef.current && !groupByMenuRef.current.contains(e.target as Node)) {
+				setGroupByMenuOpen(false)
+			}
+		}
+		activeDocument.addEventListener('mousedown', handler)
+		return () => activeDocument.removeEventListener('mousedown', handler)
+	}, [groupByMenuOpen])
 
 	// ── Fechar menu de ações ao clicar fora ──────────────────────────────────
 
@@ -1684,6 +1738,13 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 
 	const isMobile = useIsMobile()
 
+	const tableRows = table.getRowModel().rows
+
+	// Must stay above the early returns below: a hook skipped on the loading
+	// render but called on the next one breaks React's hook ordering.
+	const { groups: rowGroups, collapsedGroups, toggleGroup, collapseAll, expandAll } =
+		useGrouping(config.schema, activeView, tableRows, readTableRowValue)
+
 	if (!dbFile) {
 		return (
 			<div className="nb-empty-state">
@@ -1697,10 +1758,21 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 		return <div className="nb-loading">{t('loading')}</div>
 	}
 
-	const tableRows = table.getRowModel().rows
+	const groupByMenuProps = {
+		groupableColumns,
+		activeColumnId: activeView.groupByColumnId,
+		hideEmpty: activeView.boardHideEmpty ?? false,
+		hideNoValue: activeView.boardHideNoValue ?? false,
+		onSelect: (id: string | undefined) => { void saveView({ ...activeView, groupByColumnId: id }); setGroupByMenuOpen(false) },
+		onToggleHideEmpty: (next: boolean) => { void saveView({ ...activeView, boardHideEmpty: next }) },
+		onToggleHideNoValue: (next: boolean) => { void saveView({ ...activeView, boardHideNoValue: next }) },
+		onCollapseAll: collapseAll,
+		onExpandAll: expandAll,
+	}
 
 	const closeMobileMenus = (except?: string) => {
 		if (except !== 'fields') setFieldsMenuOpen(false)
+		if (except !== 'groupby') setGroupByMenuOpen(false)
 		if (except !== 'actions') setActionsMenuOpen(false)
 		if (except !== 'filter') setFilterMenuOpen(false)
 		if (except !== 'sort') setSortPanelOpen(false)
@@ -1713,6 +1785,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 			actions={[
 				{ id: 'fields', label: t('fields'), icon: <IconFields />, active: fieldsMenuOpen, badge: config.schema.filter(c => !c.visible).length || undefined, onClick: () => { closeMobileMenus('fields'); setFieldsMenuOpen(v => !v) } },
 				{ id: 'actions', label: t('actions'), icon: <IconActions />, active: actionsMenuOpen, badge: table.getSelectedRowModel().rows.length || undefined, onClick: () => { closeMobileMenus('actions'); setActionsMenuOpen(v => !v) } },
+				...(groupableColumns.length > 0 ? [{ id: 'groupby', label: t('group_by'), icon: <IconSort />, active: groupByMenuOpen, onClick: () => { closeMobileMenus('groupby'); setGroupByMenuOpen(v => !v) } }] : []),
 				{ id: 'subfolders', label: t('tooltip_include_subfolders'), icon: <IconSubfolders />, active: !!activeView.includeSubfolders, onClick: () => { closeMobileMenus(); void toggleIncludeSubfolders() } },
 				{ id: 'sort', label: t('sort'), icon: <IconSort />, active: activeView.sorts.length > 0, badge: activeView.sorts.length || undefined, onClick: () => { closeMobileMenus('sort'); if (!sortPanelOpen && sortButtonRef.current) setSortAnchorRect(sortButtonRef.current.getBoundingClientRect()); setSortPanelOpen(v => !v) } },
 				{ id: 'filter', label: t('filter'), icon: <IconFilter />, active: filterMenuOpen, badge: activeFilters.length || undefined, onClick: () => { closeMobileMenus('filter'); setFilterMenuOpen(v => !v) } },
@@ -1732,6 +1805,9 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 						<span className="nb-field-name">{col.name}</span>
 					</label>
 				))}
+			</BottomSheet>
+			<BottomSheet open={groupByMenuOpen} onClose={() => setGroupByMenuOpen(false)} title={t('group_by')}>
+				<GroupByMenu {...groupByMenuProps} />
 			</BottomSheet>
 			<BottomSheet open={actionsMenuOpen} onClose={() => setActionsMenuOpen(false)} title={t('actions')}>
 				<button className="nb-menu-item" onClick={() => { void handleDeleteSelected() }} disabled={table.getSelectedRowModel().rows.length === 0}>
@@ -1888,6 +1964,16 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 						<line x1="12" y1="11" x2="12" y2="17"/><line x1="9" y1="14" x2="15" y2="14"/>
 					</svg>
 				</button>
+
+				{/* Agrupar por */}
+				{groupableColumns.length > 0 && (
+					<div className="nb-fields-menu-wrapper" ref={groupByMenuRef}>
+						<button className={`nb-toolbar-btn${groupByMenuOpen ? ' nb-toolbar-btn--active' : ''}`} onClick={() => setGroupByMenuOpen(v => !v)}>
+							{t('group_by')}: <strong>{groupByCol?.name ?? t('group_none')}</strong>
+						</button>
+						{groupByMenuOpen && <GroupByMenu {...groupByMenuProps} />}
+					</div>
+				)}
 
 				{/* Botão Campos */}
 				<div className="nb-fields-menu-wrapper" ref={fieldsMenuRef}>
@@ -2334,32 +2420,59 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 						})}
 					</thead>
 
-					<VirtualTbody
-						scrollRef={tableWrapperRef}
-						rowHeight={activeView.rowHeight === 'compact' ? 28 : activeView.rowHeight === 'tall' ? 64 : 36}
-						disableVirtual={config.schema.some(c => c.wrap && !activeView.hiddenColumns.includes(c.id))}
-						rows={tableRows as VirtualTbodyProps['rows']}
-						stickyMap={stickyMap}
-						isMobile={isMobile}
-						setEditingCell={setEditingCell}
-						setContextMenuFile={setContextMenuFile}
-						longPressRef={longPressRef}
-						columns={columns}
-						onAddRow={() => { void handleAddRow() }}
-						hierarchyMap={hierarchyMap}
-						onToggleExpand={toggleHierarchyExpand}
-						onAddSubRow={parentTitle => { void handleAddSubRow(parentTitle) }}
-						expandedSet={hierarchyExpandedSet}
-						allExpanded={hierarchyAllExpanded}
-						rowDragEnabled={rowDragEnabled}
-						dragOverPath={dragOverRowPath}
-						onRowDragStart={handleRowDragStart}
-						onRowDragOver={handleRowDragOver}
-						onRowDragEnd={handleRowDragEnd}
-						onRowDrop={handleRowDrop}
-						conditionalFormats={activeView.conditionalFormats}
-						schema={config.schema}
-					/>
+					{(() => {
+						const tbodyProps = {
+							scrollRef: tableWrapperRef,
+							rowHeight: activeView.rowHeight === 'compact' ? 28 : activeView.rowHeight === 'tall' ? 64 : 36,
+							stickyMap,
+							isMobile,
+							setEditingCell,
+							setContextMenuFile,
+							longPressRef,
+							columns,
+							// Grouping takes precedence over hierarchy nesting and manual row order
+							hierarchyMap: groupByCol ? null : hierarchyMap,
+							onToggleExpand: toggleHierarchyExpand,
+							onAddSubRow: (parentTitle: string) => { void handleAddSubRow(parentTitle) },
+							expandedSet: hierarchyExpandedSet,
+							allExpanded: hierarchyAllExpanded,
+							rowDragEnabled: rowDragEnabled && !groupByCol,
+							dragOverPath: dragOverRowPath,
+							onRowDragStart: handleRowDragStart,
+							onRowDragOver: handleRowDragOver,
+							onRowDragEnd: handleRowDragEnd,
+							onRowDrop: handleRowDrop,
+							conditionalFormats: activeView.conditionalFormats,
+							schema: config.schema,
+						}
+						if (!rowGroups) {
+							return (
+								<VirtualTbody
+									{...tbodyProps}
+									disableVirtual={config.schema.some(c => c.wrap && !activeView.hiddenColumns.includes(c.id))}
+									rows={tableRows as VirtualTbodyProps['rows']}
+									onAddRow={() => { void handleAddRow() }}
+								/>
+							)
+						}
+						return rowGroups.map(group => (
+							<VirtualTbody
+								key={group.value}
+								{...tbodyProps}
+								disableVirtual
+								rows={group.items as VirtualTbodyProps['rows']}
+								onAddRow={() => { void handleAddRowToGroup(group.value) }}
+								groupHeader={{
+									label: group.label,
+									color: group.color,
+									count: group.items.length,
+									collapsed: collapsedGroups.has(group.value),
+									onToggle: () => toggleGroup(group.value),
+									onAdd: () => { void handleAddRowToGroup(group.value) },
+								}}
+							/>
+						))
+					})()}
 					<tfoot className="nb-tfoot">
 					<tr>
 						<td className="nb-td nb-agg-td nb-td--sticky" style={{ left: 0, zIndex: 1, width: 40 }} />

--- a/src/components/GroupHeader.tsx
+++ b/src/components/GroupHeader.tsx
@@ -1,0 +1,107 @@
+import React from 'react'
+import { ColumnSchema } from '../types'
+import { getColumnIconStatic } from './filter-utils'
+import { t } from '../i18n'
+
+// ── Group header ────────────────────────────────────────────────────────────
+
+export interface GroupHeaderProps {
+	label: string
+	color?: string
+	count: number
+	collapsed: boolean
+	onToggle: () => void
+	onAdd: () => void
+}
+
+export function GroupHeader({ label, color, count, collapsed, onToggle, onAdd }: GroupHeaderProps) {
+	return (
+		<div className="nb-group-header" onClick={onToggle}>
+			<button
+				className="nb-hierarchy-toggle"
+				aria-expanded={!collapsed}
+				title={collapsed ? t('expand_all') : t('collapse_all')}
+			>
+				{collapsed ? '▶' : '▼'}
+			</button>
+			{color ? <span className="nb-group-header-dot" style={{ backgroundColor: color }} /> : null}
+			<span className="nb-group-header-label">{label}</span>
+			<span className="nb-group-header-count">{count}</span>
+			<button
+				className="nb-group-header-add"
+				onClick={e => { e.stopPropagation(); onAdd() }}
+				title={t('add_entry')}
+			>
+				+
+			</button>
+		</div>
+	)
+}
+
+// ── Group by dropdown ───────────────────────────────────────────────────────
+
+export interface GroupByMenuProps {
+	groupableColumns: ColumnSchema[]
+	activeColumnId?: string
+	hideEmpty: boolean
+	hideNoValue: boolean
+	onSelect: (columnId: string | undefined) => void
+	onToggleHideEmpty: (next: boolean) => void
+	onToggleHideNoValue: (next: boolean) => void
+	onCollapseAll: () => void
+	onExpandAll: () => void
+}
+
+export function GroupByMenu({
+	groupableColumns, activeColumnId, hideEmpty, hideNoValue,
+	onSelect, onToggleHideEmpty, onToggleHideNoValue, onCollapseAll, onExpandAll,
+}: GroupByMenuProps) {
+	const grouped = groupableColumns.some(c => c.id === activeColumnId)
+	return (
+		<div className="nb-fields-dropdown">
+			<div className="nb-fields-dropdown-label">{t('group_by_label')}</div>
+			<button
+				className={`nb-menu-item${!activeColumnId ? ' nb-menu-item--active' : ''}`}
+				onClick={() => onSelect(undefined)}
+			>
+				<span>{t('group_none')}</span>
+			</button>
+			{groupableColumns.map(col => (
+				<button
+					key={col.id}
+					className={`nb-menu-item${activeColumnId === col.id ? ' nb-menu-item--active' : ''}`}
+					onClick={() => onSelect(col.id)}
+				>
+					<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+					<span>{col.name}</span>
+				</button>
+			))}
+			{grouped && (
+				<>
+					<div className="nb-menu-separator" />
+					<label className="nb-field-row">
+						<input
+							type="checkbox"
+							className="nb-field-checkbox"
+							checked={hideEmpty}
+							onChange={e => onToggleHideEmpty(e.target.checked)}
+						/>
+						<span className="nb-field-name">{t('hide_empty_cols')}</span>
+					</label>
+					<label className="nb-field-row">
+						<input
+							type="checkbox"
+							className="nb-field-checkbox"
+							checked={hideNoValue}
+							onChange={e => onToggleHideNoValue(e.target.checked)}
+						/>
+						<span className="nb-field-name">{t('hide_no_value_cols')}</span>
+					</label>
+					<div className="nb-menu-separator" />
+					<button className="nb-menu-item" onClick={onCollapseAll}><span>{t('collapse_all')}</span></button>
+					<button className="nb-menu-item" onClick={onExpandAll}><span>{t('expand_all')}</span></button>
+				</>
+			)}
+		</div>
+	)
+}

--- a/src/components/group-utils.ts
+++ b/src/components/group-utils.ts
@@ -1,0 +1,96 @@
+import { ColumnSchema, SelectOption } from '../types'
+import { stringifyScalar } from '../value-utils'
+import { t } from '../i18n'
+
+/**
+ * A single group axis bucket. `value` is the raw frontmatter value written when
+ * adding an item to the group; the no-value bucket uses ''.
+ */
+export interface GroupDef<T> {
+	value: string
+	label: string
+	color?: string
+	items: T[]
+}
+
+export interface BuildGroupsOptions {
+	/** Saved manual group order (board views persist this as boardColumnOrder). */
+	order?: string[]
+	hideEmpty?: boolean
+	hideNoValue?: boolean
+}
+
+/** Grouping requires a single-value axis, so only select and status qualify. */
+export function getGroupableColumns(schema: ColumnSchema[]): ColumnSchema[] {
+	return schema.filter(c => c.type === 'select' || c.type === 'status')
+}
+
+/** Called on every render so the labels follow the active locale. */
+function DEFAULT_STATUS_OPTIONS(): SelectOption[] {
+	return [
+		{ value: t('status_not_started'), color: '#9E9E9E' },
+		{ value: t('status_in_progress'), color: '#2196F3' },
+		{ value: t('status_done'), color: '#4CAF50' },
+		{ value: t('status_cancelled'), color: '#F44336' },
+	]
+}
+
+function getGroupOptions(column: ColumnSchema): SelectOption[] {
+	if (column.type === 'status' && !column.options?.length) return DEFAULT_STATUS_OPTIONS()
+	return column.options ?? []
+}
+
+function normalize(value: unknown): string {
+	return stringifyScalar(value).trim()
+}
+
+/**
+ * Bucket items by a select/status column.
+ *
+ * Order: declared options, then values found in the data but missing from the
+ * options, then the no-value bucket. The undeclared pass exists so a stale
+ * schema cannot silently drop rows.
+ */
+export function buildGroups<T>(
+	items: T[],
+	getValue: (item: T) => unknown,
+	column: ColumnSchema,
+	opts: BuildGroupsOptions = {},
+): GroupDef<T>[] {
+	const declared = getGroupOptions(column)
+	const buckets = new Map<string, T[]>()
+	for (const opt of declared) buckets.set(opt.value, [])
+
+	const undeclared: string[] = []
+	const noValue: T[] = []
+
+	for (const item of items) {
+		const value = normalize(getValue(item))
+		if (value === '') { noValue.push(item); continue }
+		let bucket = buckets.get(value)
+		if (!bucket) { bucket = []; buckets.set(value, bucket); undeclared.push(value) }
+		bucket.push(item)
+	}
+
+	const all: GroupDef<T>[] = [
+		...declared.map(opt => ({
+			value: opt.value,
+			label: opt.value,
+			color: opt.color,
+			items: buckets.get(opt.value) ?? [],
+		})),
+		...undeclared.map(value => ({ value, label: value, items: buckets.get(value) ?? [] })),
+		{ value: '', label: t('no_value'), items: noValue },
+	]
+
+	let ordered = all
+	const order = opts.order
+	if (order && order.length > 0) {
+		const inOrder = order.flatMap(v => { const g = all.find(x => x.value === v); return g ? [g] : [] })
+		ordered = [...inOrder, ...all.filter(x => !order.includes(x.value))]
+	}
+
+	let result = opts.hideEmpty ? ordered.filter(g => g.items.length > 0) : ordered
+	if (opts.hideNoValue) result = result.filter(g => g.value !== '')
+	return result
+}

--- a/src/hooks/useGrouping.ts
+++ b/src/hooks/useGrouping.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ColumnSchema, ViewConfig } from '../types'
+import { buildGroups, getGroupableColumns, GroupDef } from '../components/group-utils'
+
+interface GroupingResult<T> {
+	groupableColumns: ColumnSchema[]
+	groupByCol: ColumnSchema | null
+	/** null when the view is not grouped, so callers can keep their flat render path. */
+	groups: GroupDef<T>[] | null
+	collapsedGroups: Set<string>
+	toggleGroup: (value: string) => void
+	collapseAll: () => void
+	expandAll: () => void
+}
+
+/**
+ * Grouping state shared by the table, list and gallery views.
+ *
+ * Collapsed state lives here and is deliberately not persisted: writing it to
+ * the view config would rewrite _database.md on every toggle.
+ */
+export function useGrouping<T>(
+	schema: ColumnSchema[],
+	view: ViewConfig,
+	items: T[],
+	getValue: (item: T, columnId: string) => unknown,
+): GroupingResult<T> {
+	const groupableColumns = useMemo(() => getGroupableColumns(schema), [schema])
+	const groupByCol = useMemo(
+		() => schema.find(c => c.id === view.groupByColumnId) ?? null,
+		[schema, view.groupByColumnId],
+	)
+	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
+
+	// Two columns can share an option value ("High"), so a stale collapse would
+	// carry over to the new axis. Start every axis fully expanded.
+	useEffect(() => { setCollapsedGroups(new Set()) }, [groupByCol?.id])
+
+	const groups = useMemo(() => {
+		if (!groupByCol) return null
+		return buildGroups(items, item => getValue(item, groupByCol.id), groupByCol, {
+			order: view.boardColumnOrder,
+			hideEmpty: view.boardHideEmpty,
+			hideNoValue: view.boardHideNoValue,
+		})
+	}, [groupByCol, items, getValue, view.boardColumnOrder, view.boardHideEmpty, view.boardHideNoValue])
+
+	const toggleGroup = useCallback((value: string) => {
+		setCollapsedGroups(prev => {
+			const next = new Set(prev)
+			if (next.has(value)) next.delete(value)
+			else next.add(value)
+			return next
+		})
+	}, [])
+
+	const collapseAll = useCallback(() => {
+		setCollapsedGroups(new Set((groups ?? []).map(g => g.value)))
+	}, [groups])
+
+	const expandAll = useCallback(() => setCollapsedGroups(new Set()), [])
+
+	return { groupableColumns, groupByCol, groups, collapsedGroups, toggleGroup, collapseAll, expandAll }
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -35,6 +35,7 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	filter_by: 'Filtern nach',
 	sort_by: 'Sortieren nach',
 	group_by_label: 'Gruppieren nach',
+	group_none: 'Keine',
 	date_field_label: 'Datumsfeld',
 	cover_field_label: 'Titelbildfeld',
 	card_size_label: 'Kartengröße',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -33,6 +33,7 @@ const en = {
 	filter_by: 'Filter by',
 	sort_by: 'Sort by',
 	group_by_label: 'Group by',
+	group_none: 'None',
 	date_field_label: 'Date field',
 	cover_field_label: 'Cover field',
 	card_size_label: 'Card size',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -35,6 +35,7 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	filter_by: 'Filtrar por',
 	sort_by: 'Ordenar por',
 	group_by_label: 'Agrupar por',
+	group_none: 'Ninguno',
 	date_field_label: 'Campo de fecha',
 	cover_field_label: 'Campo de portada',
 	card_size_label: 'Tamaño de tarjeta',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -35,6 +35,7 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	filter_by: 'Filtrer par',
 	sort_by: 'Trier par',
 	group_by_label: 'Grouper par',
+	group_none: 'Aucun',
 	date_field_label: 'Champ de date',
 	cover_field_label: 'Champ de couverture',
 	card_size_label: 'Taille de carte',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -35,6 +35,7 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	filter_by: 'フィルター条件',
 	sort_by: '並べ替え条件',
 	group_by_label: 'グループ化条件',
+	group_none: 'なし',
 	date_field_label: '日付フィールド',
 	cover_field_label: 'カバーフィールド',
 	card_size_label: 'カードサイズ',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -35,6 +35,7 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	filter_by: 'Filtrar por',
 	sort_by: 'Ordenar por',
 	group_by_label: 'Agrupar por',
+	group_none: 'Nenhum',
 	date_field_label: 'Campo de data',
 	cover_field_label: 'Campo de capa',
 	card_size_label: 'Tamanho dos cards',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -35,6 +35,7 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	filter_by: '筛选条件',
 	sort_by: '排序条件',
 	group_by_label: '分组条件',
+	group_none: '无',
 	date_field_label: '日期字段',
 	cover_field_label: '封面字段',
 	card_size_label: '卡片大小',

--- a/styles.css
+++ b/styles.css
@@ -5742,3 +5742,65 @@ body.nb-tl-resizing.nb-tl-resizing.nb-tl-resizing * {
 	white-space: nowrap;
 	vertical-align: baseline;
 }
+
+/* ── Collapsible groups (table / list / gallery) ─────────────────────────── */
+
+.nb-group-header {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 8px;
+	cursor: pointer;
+	user-select: none;
+	background: var(--background-secondary);
+	border-top: 1px solid var(--background-modifier-border);
+	font-size: 0.85em;
+}
+
+.nb-group-header:hover {
+	background: var(--background-modifier-hover);
+}
+
+.nb-group-header-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.nb-group-header-label {
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+.nb-group-header-count {
+	color: var(--text-muted);
+	font-variant-numeric: tabular-nums;
+}
+
+.nb-group-header-add {
+	margin-left: auto;
+	background: none;
+	border: none;
+	color: var(--text-muted);
+	cursor: pointer;
+	padding: 0 6px;
+	font-size: 1.1em;
+	line-height: 1;
+}
+
+.nb-group-header-add:hover {
+	color: var(--text-normal);
+}
+
+.nb-group-header-td {
+	padding: 0;
+}
+
+.nb-group-header-row .nb-group-header {
+	border-top: none;
+}
+
+.nb-gallery-group {
+	grid-column: 1 / -1;
+}

--- a/tests/group-utils.test.ts
+++ b/tests/group-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { buildGroups, getGroupableColumns } from '../src/components/group-utils'
+import { ColumnSchema } from '../src/types'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function selectCol(overrides: Partial<ColumnSchema> = {}): ColumnSchema {
+	return {
+		id: 'subject',
+		name: 'Subject',
+		type: 'select',
+		visible: true,
+		options: [
+			{ value: 'network', color: '#ff0000' },
+			{ value: 'database', color: '#00ff00' },
+		],
+		...overrides,
+	}
+}
+
+interface Row { subject?: unknown }
+
+function rows(...values: unknown[]): Row[] {
+	return values.map(v => ({ subject: v }))
+}
+
+const getSubject = (r: Row) => r.subject
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('getGroupableColumns', () => {
+	it('keeps only select and status columns', () => {
+		const schema: ColumnSchema[] = [
+			{ id: 'a', name: 'A', type: 'select', visible: true },
+			{ id: 'b', name: 'B', type: 'status', visible: true },
+			{ id: 'c', name: 'C', type: 'multiselect', visible: true },
+			{ id: 'd', name: 'D', type: 'text', visible: true },
+		]
+		expect(getGroupableColumns(schema).map(c => c.id)).toEqual(['a', 'b'])
+	})
+})
+
+describe('buildGroups', () => {
+	it('keeps declared option order and appends the no-value group last', () => {
+		const result = buildGroups(rows('database', 'network', null), getSubject, selectCol())
+		expect(result.map(g => g.value)).toEqual(['network', 'database', ''])
+	})
+
+	it('counts items per group', () => {
+		const result = buildGroups(rows('network', 'network', 'database'), getSubject, selectCol())
+		expect(result.map(g => g.items.length)).toEqual([2, 1, 0])
+	})
+
+	it('carries the option color onto the group', () => {
+		const result = buildGroups(rows('network'), getSubject, selectCol())
+		expect(result[0].color).toBe('#ff0000')
+	})
+
+	it('treats null, undefined, empty string and whitespace as no value', () => {
+		const result = buildGroups(rows(null, undefined, '', '   '), getSubject, selectCol())
+		const noValue = result.find(g => g.value === '')
+		expect(noValue?.items).toHaveLength(4)
+	})
+
+	it('groups values present in the data but missing from the options, after the declared ones', () => {
+		const result = buildGroups(rows('network', 'storage', 'kubernetes'), getSubject, selectCol())
+		expect(result.map(g => g.value)).toEqual(['network', 'database', 'storage', 'kubernetes', ''])
+	})
+
+	it('drops empty groups when hideEmpty is set', () => {
+		const result = buildGroups(rows('network'), getSubject, selectCol(), { hideEmpty: true })
+		expect(result.map(g => g.value)).toEqual(['network'])
+	})
+
+	it('drops the no-value group when hideNoValue is set', () => {
+		const result = buildGroups(rows('network', null), getSubject, selectCol(), { hideNoValue: true })
+		expect(result.map(g => g.value)).toEqual(['network', 'database'])
+	})
+
+	it('applies a saved order first and appends the rest in natural order', () => {
+		const result = buildGroups(rows('network', 'database', 'storage'), getSubject, selectCol(), {
+			order: ['database', 'network'],
+		})
+		expect(result.map(g => g.value)).toEqual(['database', 'network', 'storage', ''])
+	})
+
+	it('ignores saved order entries whose group no longer exists', () => {
+		const result = buildGroups(rows('network'), getSubject, selectCol(), { order: ['gone', 'database'] })
+		expect(result.map(g => g.value)).toEqual(['database', 'network', ''])
+	})
+
+	it('falls back to the four default options for a status column with no options', () => {
+		const col = selectCol({ type: 'status', options: undefined })
+		const result = buildGroups([], getSubject, col)
+		expect(result).toHaveLength(5)
+		expect(result[result.length - 1].value).toBe('')
+	})
+
+	it('returns every declared group with zero items for an empty input', () => {
+		const result = buildGroups([], getSubject, selectCol())
+		expect(result.map(g => g.value)).toEqual(['network', 'database', ''])
+		expect(result.every(g => g.items.length === 0)).toBe(true)
+	})
+
+	it('matches numeric frontmatter values against string options', () => {
+		const col = selectCol({ options: [{ value: '1' }, { value: '2' }] })
+		const result = buildGroups(rows(1, 2, 2), getSubject, col)
+		expect(result.map(g => g.items.length)).toEqual([1, 2, 0])
+	})
+})


### PR DESCRIPTION
## TL;DR

`ViewConfig.groupByColumnId` is already a shared field, but only the Board view ever read it. To see notes split by a single-select property you had to switch to a kanban board, with no way to get the same grouping as a table, list or gallery. This PR lets the Table, List and Gallery views read that same field and render collapsible groups, reusing the Board's grouping semantics and its two empty-group toggles. No new `ViewConfig` fields, no migration, and no change at all when the field is unset.

Group headers carry the option colour, the label, the item count and a `+` button that creates a note with the group's value already in the frontmatter, matching what `addCardToColumn` does on the board.

## What changed

- **New** `src/components/group-utils.ts` — the Board's grouping memo extracted into a generic pure function shared by all four views
- **New** `src/components/GroupHeader.tsx` — group header and the Group by dropdown
- **New** `src/hooks/useGrouping.ts` — grouping state shared by the three views
- **New** `tests/group-utils.test.ts` — 13 cases covering the grouping logic
- **Changed** Table / List / Gallery — Group by menu in the toolbar, grouped rendering, per-group add
- **Changed** Board — its `columns` memo now calls the shared helper, dropping from 33 lines to 8
- **Changed** i18n — one new key, `group_none`

## Design decisions

- **Group axis stays `select` / `status`.** `getGroupableColumns` keeps the Board's existing filter. Allowing `multiselect` would put one note in several groups and leave per-group add ambiguous about which value to write.
- **Empty-group toggles reuse `boardHideEmpty` / `boardHideNoValue`** (from #47) instead of parallel fields. They mean the same thing here, so a view keeps its setting if its type changes. The `board` prefix is now a slight misnomer, but renaming with a fallback seemed worse than living with the name.
- **Collapsed state is not persisted.** It lives in `useGrouping` and resets when the view is reopened. Writing it to the view config would rewrite `_database.md` on every collapse, which is diff noise for vaults tracked in git. `Collapse all` / `Expand all` cover the cost of re-collapsing. It also resets when the grouping column changes, since two columns can share an option value.
- **Table renders one `<tbody>` per group.** Column widths resolve at the table level, so multiple table bodies stay aligned.
- **Grouping turns off pagination, virtual scrolling, hierarchy nesting and manual row order.** None of them are aware of group boundaries, and a group split across a page boundary would make the header count wrong. The existing `disableVirtual` prop is reused.
- **Calendar, Timeline and Chart are out of scope.** Timeline already groups through `timelineGroupByField`; the other two are keyed on dates or aggregates, where collapsing groups maps onto nothing.

## Behaviour change worth flagging

`buildGroups` compares values with `stringifyScalar(...).trim()` rather than the Board's previous strict `===`, and appends a group for values present in the data but absent from the column options.

- **Before:** a row whose value was not in the options list matched no bucket and was silently dropped from the board
- **After:** it lands in a group named after its actual value
- **Why it matters:** easy to miss in a kanban, very visible in a table, where a few rows would simply be gone from a 105-row database
- **Impact:** this changes what the Board renders for databases with a stale schema, in the direction of showing rows that were previously invisible

## Without `groupByColumnId`

- All three views take their original render path unchanged: flat list, pagination on, virtual scrolling on
- The Board's "fall back to the first groupable column when unset" behaviour stays Board-only
- For the other three views, unset means not grouped

## Testing

- 195 unit tests passing (13 new), lint clean, production build ok
- Every commit compiles on its own, so `git bisect` stays usable
- Verified by hand in a vault of 105 notes split into 7 groups by a single-select property: header counts, collapse and expand, per-group add, both empty-group toggles, collapse/expand all, column alignment across groups, and returning to the ungrouped table
- **Gap:** the repo has no React component test infrastructure, so the view wiring is not covered by automated tests. The logic that could be extracted into a pure function was, and that part is tested
