### PR TITLE
fix: keep filter input mounted and focused while typing

### DIFF
--- a/src/components/DatabaseBoard.tsx
+++ b/src/components/DatabaseBoard.tsx
@@ -11,6 +11,7 @@ import {
 	getCardConditionalStyle,
 } from './filter-utils'
 import { FilterPillsRow } from './FilterPillsRow'
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
@@ -483,10 +484,12 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 		}
 	}, [app, dbFile, manager, groupByCol, trackSave])
 
-	const saveActivePills = useCallback(async (filters: ActiveFilter[]) => {
+	const saveActivePillsNow = useCallback(async (filters: ActiveFilter[]) => {
 		const pills = filters.map(f => ({ id: f.id, columnId: f.columnId, operator: f.operator, value: f.value, conjunction: f.conjunction }))
 		await saveView({ ...activeView, activePills: pills })
 	}, [saveView, activeView])
+	// Debounced: typing a filter value must not persist per keystroke (#60)
+	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
 	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]

--- a/src/components/DatabaseCalendar.tsx
+++ b/src/components/DatabaseCalendar.tsx
@@ -10,6 +10,7 @@ import {
 	getColumnIconStatic, getDefaultOperator,
 } from './filter-utils'
 import { FilterPillsRow } from './FilterPillsRow'
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
@@ -279,10 +280,12 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 
 	// ── Actions ───────────────────────────────────────────────────────────────
 
-	const saveActivePills = useCallback(async (filters: ActiveFilter[]) => {
+	const saveActivePillsNow = useCallback(async (filters: ActiveFilter[]) => {
 		const pills = filters.map(f => ({ id: f.id, columnId: f.columnId, operator: f.operator, value: f.value, conjunction: f.conjunction }))
 		await saveView({ ...activeView, activePills: pills })
 	}, [saveView, activeView])
+	// Debounced: typing a filter value must not persist per keystroke (#60)
+	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
 	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]

--- a/src/components/DatabaseCharts.tsx
+++ b/src/components/DatabaseCharts.tsx
@@ -11,6 +11,7 @@ import {
 	getColumnIconStatic, getDefaultOperator,
 } from './filter-utils'
 import { FilterPillsRow } from './FilterPillsRow'
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
@@ -571,10 +572,12 @@ export function DatabaseCharts({ dbFile, manager, externalView, onViewChange }: 
 
 	// ── Filter actions ───────────────────────────────────────────────────────
 
-	const saveActivePills = useCallback(async (filters: ActiveFilter[]) => {
+	const saveActivePillsNow = useCallback(async (filters: ActiveFilter[]) => {
 		const pills = filters.map(f => ({ id: f.id, columnId: f.columnId, operator: f.operator, value: f.value, conjunction: f.conjunction }))
 		await saveView({ ...activeView, activePills: pills })
 	}, [saveView, activeView])
+	// Debounced: typing a filter value must not persist per keystroke (#60)
+	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
 	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]

--- a/src/components/DatabaseGallery.tsx
+++ b/src/components/DatabaseGallery.tsx
@@ -12,6 +12,7 @@ import {
 	getCardConditionalStyle,
 } from './filter-utils'
 import { FilterPillsRow } from './FilterPillsRow'
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
@@ -282,10 +283,12 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 
 	// ── Actions ───────────────────────────────────────────────────────────────
 
-	const saveActivePills = useCallback(async (filters: ActiveFilter[]) => {
+	const saveActivePillsNow = useCallback(async (filters: ActiveFilter[]) => {
 		const pills = filters.map(f => ({ id: f.id, columnId: f.columnId, operator: f.operator, value: f.value, conjunction: f.conjunction }))
 		await saveView({ ...activeView, activePills: pills })
 	}, [saveView, activeView])
+	// Debounced: typing a filter value must not persist per keystroke (#60)
+	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
 	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]

--- a/src/components/DatabaseList.tsx
+++ b/src/components/DatabaseList.tsx
@@ -12,6 +12,7 @@ import {
 	getCardConditionalStyle,
 } from './filter-utils'
 import { FilterPillsRow } from './FilterPillsRow'
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
@@ -232,10 +233,12 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 
 	// ── Filter actions ───────────────────────────────────────────────────────
 
-	const saveActivePills = useCallback(async (filters: ActiveFilter[]) => {
+	const saveActivePillsNow = useCallback(async (filters: ActiveFilter[]) => {
 		const pills = filters.map(f => ({ id: f.id, columnId: f.columnId, operator: f.operator, value: f.value, conjunction: f.conjunction }))
 		await saveView({ ...activeView, activePills: pills })
 	}, [saveView, activeView])
+	// Debounced: typing a filter value must not persist per keystroke (#60)
+	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
 	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]

--- a/src/components/DatabaseTable.tsx
+++ b/src/components/DatabaseTable.tsx
@@ -34,6 +34,7 @@ import { DatabaseManager } from '../database-manager'
 import { ColumnSchema, ColumnType, ConditionalFormatRule, DatabaseConfig, FilterOperator, NoteRow, SortConfig, ViewConfig, AggregationType, DEFAULT_DATABASE_CONFIG, DEFAULT_VIEW } from '../types'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { ColumnHeader } from './ColumnHeader'
 import { CellRenderer, CellContext } from './cells/CellRenderer'
 import { FolderPickerModal } from '../folder-picker-modal'
@@ -737,6 +738,11 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 	const [relationOptions, setRelationOptions] = useState<Map<string, string[]>>(new Map())
 	const [pinnedColumnId, setPinnedColumnId] = useState<string | null>(null)
 
+	// Ref keeps onLoaded stable: a dep on externalView would recreate the hook's
+	// loadData on every view config write and re-trigger reloads while typing (#60).
+	const externalViewRef = useRef(externalView)
+	externalViewRef.current = externalView
+
 	const onLoaded = useCallback((cfg: DatabaseConfig, noteRows: NoteRow[]) => {
 		// Reorder newly created row to end
 		if (lastCreatedPath.current) {
@@ -758,8 +764,8 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 			relOpts.set(col.id, Array.from(values).sort())
 		}
 		setRelationOptions(relOpts)
-		setPinnedColumnId((externalView ?? cfg.views[0])?.pinnedColumnId ?? null)
-	}, [app, manager, externalView])
+		setPinnedColumnId((externalViewRef.current ?? cfg.views[0])?.pinnedColumnId ?? null)
+	}, [app, manager])
 
 	const { rows: hookRows, config: hookConfig, loading, activeFilters, setActiveFilters } = useDatabaseRows({
 		app, dbFile, manager, includeSubfolders: externalView?.includeSubfolders, externalView: externalView ?? DEFAULT_VIEW, onLoaded,
@@ -1499,10 +1505,12 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 
 	const getColumnIcon = getColumnIconStatic
 
-	const saveActivePills = useCallback(async (filters: { columnId: string }[]) => {
+	const saveActivePillsNow = useCallback(async (filters: { columnId: string }[]) => {
 		const pills = (filters as ActiveFilter[]).map(f => ({ id: f.id, columnId: f.columnId, operator: f.operator, value: f.value, conjunction: f.conjunction }))
 		await saveView({ ...activeView, activePills: pills })
 	}, [saveView, activeView])
+	// Debounced: typing a filter value must not persist per keystroke (#60)
+	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
 	const handlePillDragEnd = (event: DragEndEvent) => {
 		const { active, over } = event

--- a/src/components/DatabaseTimeline.tsx
+++ b/src/components/DatabaseTimeline.tsx
@@ -10,6 +10,7 @@ import {
 	getColumnIconStatic, getDefaultOperator,
 } from './filter-utils'
 import { FilterPillsRow } from './FilterPillsRow'
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDatabaseRows } from '../hooks/useDatabaseRows'
@@ -370,9 +371,11 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 
 	// ── Actions ───────────────────────────────────────────────────────────────
 
-	const saveActivePills = useCallback(async (filters: ActiveFilter[]) => {
+	const saveActivePillsNow = useCallback(async (filters: ActiveFilter[]) => {
 		await saveView({ ...activeView, activePills: filters.map(f => ({ id: f.id, columnId: f.columnId, operator: f.operator, value: f.value, conjunction: f.conjunction })) })
 	}, [saveView, activeView])
+	// Debounced: typing a filter value must not persist per keystroke (#60)
+	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
 	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
 		const next = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' as const }]

--- a/src/hooks/useDatabaseRows.ts
+++ b/src/hooks/useDatabaseRows.ts
@@ -100,10 +100,19 @@ export function useDatabaseRows(options: UseDatabaseRowsOptions): UseDatabaseRow
 
 	const loadVersion = useRef(0)
 	const filtersInitialized = useRef(false)
+	const hasLoaded = useRef(false)
+
+	// Ref so loadData doesn't depend on externalView's identity — the view object
+	// is recreated on every config write (e.g. typing in a filter), and a dep here
+	// would re-trigger a full reload per keystroke (issue #60).
+	const externalViewRef = useRef(externalView)
+	externalViewRef.current = externalView
 
 	const loadData = useCallback(async () => {
 		if (!dbFile) { setLoading(false); return }
-		setLoading(true)
+		// Background refreshes keep the current UI mounted — flipping to the
+		// loading state here would unmount open dropdowns/editors and steal focus.
+		if (!hasLoaded.current) setLoading(true)
 		const version = ++loadVersion.current
 
 		const cfg = manager.readConfig(dbFile)
@@ -129,17 +138,18 @@ export function useDatabaseRows(options: UseDatabaseRowsOptions): UseDatabaseRow
 
 		if (!filtersInitialized.current) {
 			filtersInitialized.current = true
-			const pills = externalView.activePills ?? []
+			const pills = externalViewRef.current.activePills ?? []
 			setActiveFilters(restoreFilterPills(pills, cfg.schema))
 		}
 
 		setConfig({ schema: cfg.schema, views: cfg.views })
 		setRows(noteRows)
 		onLoaded?.(cfg, noteRows)
+		hasLoaded.current = true
 		setLoading(false)
-	}, [dbFile, manager, includeSubfolders, app, externalView, onLoaded])
+	}, [dbFile, manager, includeSubfolders, app, onLoaded])
 
-	useEffect(() => { filtersInitialized.current = false }, [dbFile])
+	useEffect(() => { filtersInitialized.current = false; hasLoaded.current = false }, [dbFile])
 
 	useEffect(() => { void loadData() }, [loadData])
 

--- a/src/hooks/useDebouncedCallback.ts
+++ b/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+/**
+ * Debounced wrapper around a callback: the trailing call wins, and a pending
+ * call is flushed on unmount so the last invocation is never lost. The wrapped
+ * function is read through a ref, so the returned function is stable while the
+ * flushed call always sees the latest closure.
+ */
+export function useDebouncedCallback<A extends unknown[]>(
+	fn: (...args: A) => void | Promise<void>,
+	delayMs: number,
+): (...args: A) => void {
+	const fnRef = useRef(fn)
+	fnRef.current = fn
+	const timer = useRef<number | null>(null)
+	const pendingArgs = useRef<A | null>(null)
+
+	const flush = useCallback(() => {
+		if (timer.current !== null) {
+			window.clearTimeout(timer.current)
+			timer.current = null
+		}
+		if (pendingArgs.current) {
+			const args = pendingArgs.current
+			pendingArgs.current = null
+			void fnRef.current(...args)
+		}
+	}, [])
+
+	useEffect(() => flush, [flush])
+
+	return useCallback((...args: A) => {
+		pendingArgs.current = args
+		if (timer.current !== null) window.clearTimeout(timer.current)
+		timer.current = window.setTimeout(flush, delayMs)
+	}, [flush, delayMs])
+}


### PR DESCRIPTION
# Summary

Typing in a text filter destroyed the input after every letter (#60). Two things conspired:

1. Every keystroke persisted the view config to frontmatter. The resulting `metadataCache.changed` re-ran `loadData`, which flipped the view into its loading state — and the loading early-return unmounts the whole table, filter dropdown included.
2. `loadData` depended on the `externalView` object identity, which is recreated on every config write, re-triggering reloads on its own.

# Changes

- `useDatabaseRows`: the loading state only shows before the first load; background refreshes keep the current UI mounted. `externalView` is read through a ref so config writes no longer recreate `loadData` (`onLoaded` in `DatabaseTable` got the same treatment).
- New `useDebouncedCallback` hook (trailing, 400ms, flushes pending call on unmount) wraps filter pill persistence in all seven views — live filtering stays instant, frontmatter is written once per pause instead of once per keystroke.

# Testing

- `npm run lint`, `npm run build`, `npm run test` (189 passing)
- Validated in Obsidian via CDP: typed a five-letter filter value with the dropdown staying open and focused, live filtering applied per letter, debounced value persisted to `activePills`, pill removal persisted, background frontmatter changes no longer flash the loading state.

Closes #60
