### PR TITLE
feat: image columns accept external URLs

### DIFF
--- a/src/components/DatabaseGallery.tsx
+++ b/src/components/DatabaseGallery.tsx
@@ -22,7 +22,7 @@ import { Pagination } from './Pagination'
 import { usePagination } from '../hooks/usePagination'
 import { BottomSheet } from './BottomSheet'
 import { ConditionalFormatPanel } from './ConditionalFormatPanel'
-import { stringifyScalar } from '../value-utils'
+import { stringifyScalar, isHttpUrl } from '../value-utils'
 
 interface DatabaseGalleryProps {
 	dbFile: TFile | null
@@ -123,8 +123,10 @@ const GalleryCard = React.memo(function GalleryCard({
 	const app = useApp()
 
 	const coverImagePath = coverField?.type === 'image' ? ((row as Record<string, unknown>)[coverField.id] as string | null) ?? null : null
-	const coverImageFile = coverImagePath ? app.vault.getFileByPath(coverImagePath) : null
-	const coverImageUrl = coverImageFile ? app.vault.getResourcePath(coverImageFile) : null
+	// External http(s) URLs are used as-is; anything else resolves as a vault path (#59)
+	const coverIsExternal = !!coverImagePath && isHttpUrl(coverImagePath)
+	const coverImageFile = coverImagePath && !coverIsExternal ? app.vault.getFileByPath(coverImagePath) : null
+	const coverImageUrl = coverIsExternal ? coverImagePath : (coverImageFile ? app.vault.getResourcePath(coverImageFile) : null)
 	const coverTextValue = coverField && coverField.type !== 'image'
 		? (coverField.type === 'title' ? row._title : String(((row as Record<string, unknown>)[coverField.id] as string | number | boolean | null | undefined) ?? ''))
 		: null

--- a/src/components/cells/CellRenderer.tsx
+++ b/src/components/cells/CellRenderer.tsx
@@ -17,7 +17,7 @@ interface CellProps {
 // Como não temos acesso ao `table` aqui, recebemos callbacks via prop do DatabaseTable
 // Usamos um contexto React separado para isso
 import { createContext, useContext } from 'react'
-import { stringifyScalar } from '../../value-utils'
+import { stringifyScalar, isHttpUrl } from '../../value-utils'
 import { displayLocale, formatDateText } from '../../format-cell-value'
 
 interface CellContextType {
@@ -1513,12 +1513,15 @@ function ImageCell({ col, value, isEditing, onStartEdit, onCommit, onCancel }: {
 		return () => activeDocument.removeEventListener('mousedown', h)
 	}, [isEditing, onCancel])
 
-	const imageFile = value ? app.vault.getFileByPath(value) : null
-	const imageUrl = imageFile ? app.vault.getResourcePath(imageFile) : null
+	// External http(s) URLs are used as-is; anything else resolves as a vault path (#59)
+	const isExternal = !!value && isHttpUrl(value)
+	const imageFile = value && !isExternal ? app.vault.getFileByPath(value) : null
+	const imageUrl = isExternal ? value : (imageFile ? app.vault.getResourcePath(imageFile) : null)
 
 	const openImage = (e: React.MouseEvent) => {
 		e.stopPropagation()
-		if (imageFile) void app.workspace.getLeaf(true).openFile(imageFile)
+		if (isExternal && value) window.open(value)
+		else if (imageFile) void app.workspace.getLeaf(true).openFile(imageFile)
 	}
 
 	return (
@@ -1541,6 +1544,21 @@ function ImageCell({ col, value, isEditing, onStartEdit, onCommit, onCancel }: {
 						<span>{t('image_picker_title')}</span>
 						{value && <button className="nb-image-picker-clear" onClick={e => { e.stopPropagation(); onCommit(null) }}>{t('image_picker_clear')}</button>}
 					</div>
+					<input
+						type="text"
+						className="nb-image-picker-url-input"
+						placeholder={t('image_url_placeholder')}
+						defaultValue={isExternal ? value ?? '' : ''}
+						onClick={e => e.stopPropagation()}
+						onKeyDown={e => {
+							if (e.key === 'Enter') {
+								const v = e.currentTarget.value.trim()
+								if (v === '') onCommit(null)
+								else if (isHttpUrl(v)) onCommit(v)
+							}
+							if (e.key === 'Escape') onCancel()
+						}}
+					/>
 					{images.length === 0 ? (
 						<div className="nb-image-picker-empty">
 							{col.imageSourceFolder ? `${t('image_picker_empty_folder')} "${col.imageSourceFolder}"` : t('image_picker_empty_vault')}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -259,6 +259,7 @@ const de: Partial<Record<keyof typeof en, string>> = {
 
 	// Image picker
 	image_picker_title: 'Bild auswählen',
+	image_url_placeholder: 'Bild-URL einfügen',
 	image_picker_clear: 'Löschen',
 	image_picker_empty_vault: 'Keine Bilder im Vault gefunden',
 	image_picker_empty_folder: 'Keine Bilder gefunden in',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -257,6 +257,7 @@ const en = {
 
 	// Image picker
 	image_picker_title: 'Select image',
+	image_url_placeholder: 'Paste an image URL',
 	image_picker_clear: 'Clear',
 	image_picker_empty_vault: 'No images found in vault',
 	image_picker_empty_folder: 'No images found in',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -259,6 +259,7 @@ const es: Partial<Record<keyof typeof en, string>> = {
 
 	// Image picker
 	image_picker_title: 'Seleccionar imagen',
+	image_url_placeholder: 'Pega la URL de una imagen',
 	image_picker_clear: 'Limpiar',
 	image_picker_empty_vault: 'No se encontraron imágenes en el vault',
 	image_picker_empty_folder: 'No se encontraron imágenes en',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -259,6 +259,7 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 
 	// Image picker
 	image_picker_title: 'Sélectionner une image',
+	image_url_placeholder: 'Coller l\'URL d\'une image',
 	image_picker_clear: 'Effacer',
 	image_picker_empty_vault: 'Aucune image trouvée dans le vault',
 	image_picker_empty_folder: 'Aucune image trouvée dans',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -259,6 +259,7 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 
 	// Image picker
 	image_picker_title: '画像を選択',
+	image_url_placeholder: '画像のURLを貼り付け',
 	image_picker_clear: 'クリア',
 	image_picker_empty_vault: '保管庫に画像が見つかりません',
 	image_picker_empty_folder: '画像が見つかりません：',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -259,6 +259,7 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 
 	// Image picker
 	image_picker_title: 'Selecionar imagem',
+	image_url_placeholder: 'Cole a URL de uma imagem',
 	image_picker_clear: 'Limpar',
 	image_picker_empty_vault: 'Nenhuma imagem encontrada no vault',
 	image_picker_empty_folder: 'Nenhuma imagem encontrada em',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -259,6 +259,7 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 
 	// Image picker
 	image_picker_title: '选择图片',
+	image_url_placeholder: '粘贴图片链接',
 	image_picker_clear: '清除',
 	image_picker_empty_vault: '仓库中未找到图片',
 	image_picker_empty_folder: '未找到图片于',

--- a/src/value-utils.ts
+++ b/src/value-utils.ts
@@ -15,6 +15,11 @@ export function stringifyScalar(v: unknown): string {
 	return JSON.stringify(v) ?? ''
 }
 
+/** True when the value is an absolute http(s) URL — used to tell external image sources from vault paths. */
+export function isHttpUrl(v: string): boolean {
+	return /^https?:\/\//i.test(v.trim())
+}
+
 /**
  * Epoch millis → local "YYYY-MM-DDTHH:mm" string, the storage format of date
  * cells. Local (not UTC) so system columns display the user's wall-clock time.

--- a/styles.css
+++ b/styles.css
@@ -3343,6 +3343,23 @@
 	flex-shrink: 0;
 }
 
+.nb-image-picker-url-input {
+	margin: 8px 10px 0;
+	width: calc(100% - 20px);
+	padding: 5px 8px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-size: var(--font-ui-small);
+	flex-shrink: 0;
+}
+
+.nb-image-picker-url-input:focus {
+	outline: none;
+	border-color: var(--interactive-accent);
+}
+
 .nb-image-picker-clear {
 	background: none;
 	border: none;

--- a/tests/value-utils.test.ts
+++ b/tests/value-utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { isHttpUrl } from '../src/value-utils'
+
+describe('isHttpUrl', () => {
+	it('accepts absolute http and https URLs', () => {
+		expect(isHttpUrl('https://example.com/img.png')).toBe(true)
+		expect(isHttpUrl('http://example.com/a')).toBe(true)
+		expect(isHttpUrl('HTTPS://EXAMPLE.COM/A')).toBe(true)
+		expect(isHttpUrl('  https://drive.google.com/thumbnail?id=x ')).toBe(true)
+	})
+
+	it('rejects vault paths and other schemes', () => {
+		expect(isHttpUrl('attachments/photo.png')).toBe(false)
+		expect(isHttpUrl('photo.png')).toBe(false)
+		expect(isHttpUrl('file:///c/img.png')).toBe(false)
+		expect(isHttpUrl('obsidian://open?vault=x')).toBe(false)
+		expect(isHttpUrl('httpsnot-a-url')).toBe(false)
+		expect(isHttpUrl('')).toBe(false)
+	})
+})


### PR DESCRIPTION
# Summary

Image columns now accept external URLs (#59). A value starting with `http(s)://` is used directly as the image source — in the table cell thumbnail and as the gallery card cover — while any other value keeps resolving as a vault path. The image picker gains a URL input: paste an address and press Enter to set it; submitting it empty clears the value. Clicking the link on an external image cell opens it in the browser instead of a vault leaf.

This unlocks the DAM workflow from the issue: a frontmatter field holding e.g. Google Drive preview URLs can be switched to the Image column type and immediately renders thumbnails in the table and covers in the gallery.

# Changes

- `isHttpUrl` helper in `value-utils.ts` (unit tested)
- `ImageCell`: external source rendering, open-in-browser link, picker URL input
- `GalleryCard`: cover accepts external URLs
- New locale key `image_url_placeholder` in all 7 languages; `nb-image-picker-url-input` styles

# Testing

- `npm run lint`, `npm run build`, `npm run test` (191 passing, 2 new)
- Validated in Obsidian via CDP: external URL renders in the table next to vault-path thumbs (naturalWidth > 0), gallery cover loads the external image, and the picker URL input commits `cover: https://…` to frontmatter on Enter and closes.

Closes #59
