### PR TITLE
fix: board groups include values missing from schema options

### DIFF
--- a/src/components/ColumnHeader.tsx
+++ b/src/components/ColumnHeader.tsx
@@ -55,7 +55,7 @@ interface ColumnHeaderProps {
 	schema: ColumnSchema[]
 	onUpdateSchema: (schema: ColumnSchema[]) => Promise<void>
 	onRenameColumn: (oldId: string, newName: string) => Promise<void>
-	onChangeType: (newType: ColumnType) => boolean | Promise<boolean>
+	onChangeType: (newType: ColumnType) => boolean | Partial<ColumnSchema> | Promise<boolean | Partial<ColumnSchema>>
 	manager: DatabaseManager
 	dbFile: TFile | null
 }
@@ -543,8 +543,9 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 
 	const handleTypeChange = async (type: ColumnType) => {
 		const allowed = await onChangeType(type)
-		if (!allowed) return
-		await updateCol({ type, systemField: undefined })
+		if (allowed === false) return
+		const extra = typeof allowed === 'object' ? allowed : {}
+		await updateCol({ type, systemField: undefined, ...extra })
 		if (type === 'formula') {
 			setEditingFormula(true)
 		} else if (type === 'lookup' || type === 'relation') {

--- a/src/components/DatabaseBoard.tsx
+++ b/src/components/DatabaseBoard.tsx
@@ -237,21 +237,40 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 		const options = (groupByCol.type === 'status' && !groupByCol.options?.length)
 			? DEFAULT_STATUS_OPTIONS
 			: (groupByCol.options ?? [])
+		// Frontmatter values may not be strings (e.g. numbers), so compare
+		// through the same stringification used everywhere else.
+		const groupValue = (r: (typeof sortedRows)[number]): string => {
+			const v = r[groupByCol.id]
+			return v === null || v === undefined ? '' : stringifyScalar(v).trim()
+		}
+		// Values present in notes but missing from the schema options still get
+		// a column — otherwise their cards would vanish from the board entirely.
+		const known = new Set(options.map(o => o.value))
+		const extras: string[] = []
+		for (const r of sortedRows) {
+			const v = groupValue(r)
+			if (v === '' || known.has(v)) continue
+			known.add(v)
+			extras.push(v)
+		}
 		const all = [
 			...options.map(opt => ({
 				value: opt.value,
 				label: opt.value,
 				color: opt.color,
-				rows: sortedRows.filter(r => r[groupByCol.id] === opt.value),
+				rows: sortedRows.filter(r => groupValue(r) === opt.value),
+			})),
+			...extras.map(value => ({
+				value,
+				label: value,
+				color: undefined as string | undefined,
+				rows: sortedRows.filter(r => groupValue(r) === value),
 			})),
 			{
 				value: '',
 				label: t('no_value'),
 				color: undefined,
-				rows: sortedRows.filter(r => {
-					const v = r[groupByCol.id]
-					return v === null || v === undefined || stringifyScalar(v).trim() === ''
-				}),
+				rows: sortedRows.filter(r => groupValue(r) === ''),
 			},
 		]
 		// Apply saved column order

--- a/src/components/DatabaseTable.tsx
+++ b/src/components/DatabaseTable.tsx
@@ -903,13 +903,32 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 
 	// ── Validar e trocar tipo de coluna ─────────────────────────────────────
 
-	const handleChangeColumnType = useCallback((colId: string, newType: ColumnType): boolean => {
+	const handleChangeColumnType = useCallback((colId: string, newType: ColumnType): boolean | Partial<ColumnSchema> => {
 		const col = config.schema.find(c => c.id === colId)
 		if (!col) return true
 		const error = validateTypeChange(rows, colId, col.type, newType)
 		if (error) {
 			new Notice(`${t('validate_type_change_prefix')}${error}`, 6000)
 			return false
+		}
+		// Converting to a choice type must seed the options from the values the
+		// notes already hold — otherwise views that group by this column (board)
+		// would have no columns for the existing values (#68).
+		if ((newType === 'select' || newType === 'multiselect' || newType === 'status') && !col.options?.length) {
+			const unique = new Set<string>()
+			for (const r of rows) {
+				const v = r[colId]
+				if (Array.isArray(v)) {
+					for (const item of v) {
+						const s = stringifyScalar(item).trim()
+						if (s) unique.add(s)
+					}
+				} else if (v !== null && v !== undefined) {
+					const s = stringifyScalar(v).trim()
+					if (s) unique.add(s)
+				}
+			}
+			if (unique.size > 0) return { options: Array.from(unique).map(value => ({ value })) }
 		}
 		return true
 	}, [config.schema, rows])


### PR DESCRIPTION
## Summary
- Board columns are now built from the schema options plus the distinct values actually present in the notes, so no card vanishes when the schema is out of sync
- Group value comparison goes through stringifyScalar, so numeric frontmatter values match their column
- Converting a column to select/multiselect/status now seeds its options from the existing note values (the root cause reported in the issue)

Closes #68