### PR TITLE
fix: replace emoji UI icons with monochrome SVGs and capitalize plugin name

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -36,13 +36,16 @@ export default tseslint.config(
 		rules: {
 			"@typescript-eslint/require-await": "error",
 			"@typescript-eslint/no-unnecessary-type-assertion": "error",
+			// "Bases" — proper noun, part of the plugin name "Notion Bases"
+			"obsidianmd/ui/sentence-case": ["warn", { ignoreWords: ["Bases"] }],
 		},
 	},
 	{
 		files: ["src/i18n/locales/en.ts"],
 		rules: {
 			"obsidianmd/ui/sentence-case-locale-module": ["error", {
-				ignoreWords: ["AND", "OR", "IF"],
+				// "Bases" — proper noun, part of the plugin name "Notion Bases"
+				ignoreWords: ["AND", "OR", "IF", "Bases"],
 				// Counts, filename suffixes and dataview syntax literals are not prose
 				ignoreRegex: ["^\\d", "^\\(copy", "key:: value"],
 			}],

--- a/src/components/ColumnHeader.tsx
+++ b/src/components/ColumnHeader.tsx
@@ -7,27 +7,7 @@ import { useApp } from '../context'
 import { t } from '../i18n'
 import { DatabaseManager } from '../database-manager'
 import { displayLocale, getMoment } from '../format-cell-value'
-
-const TYPE_ICONS: Record<ColumnType, string> = {
-	title:       '📄',
-	text:        'Aa',
-	number:      '#',
-	select:      '◉',
-	multiselect: '◈',
-	date:        '📅',
-	checkbox:    '☑',
-	url:         '↗',
-	email:       '✉',
-	phone:       '📞',
-	status:      '◎',
-	formula:     'ƒ',
-	relation:    '🔗',
-	lookup:      '↗',
-	rollup:      'Σ',
-	image:       '🖼',
-	audio:       '🎵',
-	video:       '🎬',
-}
+import { getColumnIcon, IconCalendar, IconClock, IconEye, IconFilm, IconImage, IconLink, IconMusic, IconPen, IconPencil, IconTrash } from './icons'
 
 const TYPE_LABELS = (): Record<ColumnType, string> => ({
 	title:       t('type_title'),
@@ -988,7 +968,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 	const dateFmtPanel = editingDateFmt && dateFmtPanelPos ? createPortal(
 		<div ref={dateFmtPanelRef} className="nb-formula-floating-panel" style={{ top: dateFmtPanelPos.y, left: dateFmtPanelPos.x }}>
 			<div className="nb-formula-titlebar" onMouseDown={handleDateFmtTitleBarMouseDown}>
-				<span className="nb-formula-titlebar-icon">📅</span>
+				<span className="nb-formula-titlebar-icon"><IconCalendar /></span>
 				<span className="nb-formula-titlebar-title">{t('date_format_title')}: {col.name}</span>
 				<button className="nb-formula-close" onClick={handleCloseDateFmt} title={t('tooltip_close')}>×</button>
 			</div>
@@ -1079,7 +1059,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 	const lookupPanel = editingLookup && lookupPanelPos ? createPortal(
 		<div ref={lookupPanelRef} className="nb-formula-floating-panel" style={{ top: lookupPanelPos.y, left: lookupPanelPos.x }}>
 			<div className="nb-formula-titlebar" onMouseDown={handleLookupTitleBarMouseDown}>
-				<span className="nb-formula-titlebar-icon">{col.type === 'relation' ? '🔗' : '↗'}</span>
+				<span className="nb-formula-titlebar-icon">{col.type === 'relation' ? <IconLink /> : '↗'}</span>
 				<span className="nb-formula-titlebar-title">{col.type === 'relation' ? t('relation_panel_title') : t('lookup_panel_title')}: {col.name}</span>
 				<button className="nb-formula-close" onClick={handleCloseLookup} title={t('tooltip_close')}>×</button>
 			</div>
@@ -1096,7 +1076,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 					<label className="nb-lookup-label">{t('lookup_col_to_display')}</label>
 					<select className="nb-lookup-select" value={lookupRefColId} onChange={e => setLookupRefColId(e.target.value)} disabled={!lookupDbPath}>
 						<option value="">{t('lookup_select_col')}</option>
-						<option value="_title">{'📄 ' + t('lookup_file_name')}</option>
+						<option value="_title">{t('lookup_file_name')}</option>
 						{refDbSchema.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
 					</select>
 				</div>
@@ -1106,7 +1086,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 						<label className="nb-lookup-label">{t('lookup_join_col')}</label>
 						<select className="nb-lookup-select" value={lookupMatchColId} onChange={e => setLookupMatchColId(e.target.value)}>
 							<option value="">{t('lookup_select_col')}</option>
-							<option value="_title">{'📄 ' + t('lookup_join_col_title')}</option>
+							<option value="_title">{t('lookup_join_col_title')}</option>
 							{schema.filter(c => c.id !== col.id && c.type !== 'formula' && c.type !== 'lookup').map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
 						</select>
 						<p className="nb-lookup-hint">{t('lookup_hint')}</p>
@@ -1145,7 +1125,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 	const imageCfgPanel = editingImageConfig && imagePanelPos ? createPortal(
 		<div ref={imgPanelRef} className="nb-formula-floating-panel" style={{ top: imagePanelPos.y, left: imagePanelPos.x, minWidth: 280 }}>
 			<div className="nb-formula-titlebar" onMouseDown={handleImageTitleBarMouseDown}>
-				<span className="nb-formula-titlebar-icon">🖼</span>
+				<span className="nb-formula-titlebar-icon"><IconImage /></span>
 				<span className="nb-formula-titlebar-title">{t('image_panel_title')}: {col.name}</span>
 				<button className="nb-formula-close" onClick={handleCloseImageConfig} title={t('tooltip_close')}>×</button>
 			</div>
@@ -1172,7 +1152,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 	const audioCfgPanel = editingAudioConfig && audioPanelPos ? createPortal(
 		<div ref={audioPanelRef} className="nb-formula-floating-panel" style={{ top: audioPanelPos.y, left: audioPanelPos.x, minWidth: 280 }}>
 			<div className="nb-formula-titlebar" onMouseDown={handleAudioTitleBarMouseDown}>
-				<span className="nb-formula-titlebar-icon">🎵</span>
+				<span className="nb-formula-titlebar-icon"><IconMusic /></span>
 				<span className="nb-formula-titlebar-title">{t('audio_panel_title')}: {col.name}</span>
 				<button className="nb-formula-close" onClick={handleCloseAudioConfig} title={t('tooltip_close')}>×</button>
 			</div>
@@ -1199,7 +1179,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 	const videoCfgPanel = editingVideoConfig && videoPanelPos ? createPortal(
 		<div ref={videoPanelRef} className="nb-formula-floating-panel" style={{ top: videoPanelPos.y, left: videoPanelPos.x, minWidth: 280 }}>
 			<div className="nb-formula-titlebar" onMouseDown={handleVideoTitleBarMouseDown}>
-				<span className="nb-formula-titlebar-icon">🎬</span>
+				<span className="nb-formula-titlebar-icon"><IconFilm /></span>
 				<span className="nb-formula-titlebar-title">{t('video_panel_title')}: {col.name}</span>
 				<button className="nb-formula-close" onClick={handleCloseVideoConfig} title={t('tooltip_close')}>×</button>
 			</div>
@@ -1245,7 +1225,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 					onClick={() => { setMenuOpen(v => !v); setEditingFormula(false); setEditingLookup(false); setEditingNumberFmt(false); setEditingDateFmt(false); setEditingImageConfig(false) }}
 					title={col.name}
 				>
-					<span className="nb-header-icon">{TYPE_ICONS[col.type]}</span>
+					<span className="nb-header-icon">{getColumnIcon(col.type)}</span>
 					<span className="nb-header-name">{col.name}</span>
 				</button>
 			)}
@@ -1254,7 +1234,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 			{menuOpen && !editingFormula && !editingLookup && !editingRollup && !editingNumberFmt && !editingDateFmt && !editingImageConfig && (
 				<div className="nb-column-menu">
 					<button className="nb-menu-item" onClick={() => { setMenuOpen(false); setRenaming(true) }}>
-						<span className="nb-menu-item-icon">✏️</span>
+						<span className="nb-menu-item-icon"><IconPencil /></span>
 						<span>{t('rename_column')}</span>
 					</button>
 
@@ -1274,7 +1254,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 
 					{col.type === 'relation' && (
 						<button className="nb-menu-item" onClick={() => setEditingLookup(true)}>
-							<span className="nb-menu-item-icon">🔗</span>
+							<span className="nb-menu-item-icon"><IconLink /></span>
 							<span>{t('configure_relation')}</span>
 						</button>
 					)}
@@ -1295,28 +1275,28 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 
 					{col.type === 'date' && (
 						<button className="nb-menu-item" onClick={() => setEditingDateFmt(true)}>
-							<span className="nb-menu-item-icon">📅</span>
+							<span className="nb-menu-item-icon"><IconCalendar /></span>
 							<span>{t('format_date')}</span>
 						</button>
 					)}
 
 					{col.type === 'image' && (
 						<button className="nb-menu-item" onClick={() => setEditingImageConfig(true)}>
-							<span className="nb-menu-item-icon">🖼</span>
+							<span className="nb-menu-item-icon"><IconImage /></span>
 							<span>{t('configure_image_folder')}</span>
 						</button>
 					)}
 
 					{col.type === 'audio' && (
 						<button className="nb-menu-item" onClick={() => setEditingAudioConfig(true)}>
-							<span className="nb-menu-item-icon">🎵</span>
+							<span className="nb-menu-item-icon"><IconMusic /></span>
 							<span>{t('configure_audio_folder')}</span>
 						</button>
 					)}
 
 					{col.type === 'video' && (
 						<button className="nb-menu-item" onClick={() => setEditingVideoConfig(true)}>
-							<span className="nb-menu-item-icon">🎬</span>
+							<span className="nb-menu-item-icon"><IconFilm /></span>
 							<span>{t('configure_video_folder')}</span>
 						</button>
 					)}
@@ -1329,7 +1309,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 							className={`nb-menu-item nb-menu-type-item ${col.type === type && !col.systemField ? 'nb-menu-item--active' : ''}`}
 							onClick={() => { void handleTypeChange(type) }}
 						>
-							<span className="nb-menu-item-icon">{TYPE_ICONS[type]}</span>
+							<span className="nb-menu-item-icon">{getColumnIcon(type)}</span>
 							<span>{TYPE_LABELS()[type]}</span>
 						</button>
 					))}
@@ -1342,7 +1322,7 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 							className={`nb-menu-item nb-menu-type-item ${col.systemField === sf ? 'nb-menu-item--active' : ''}`}
 							onClick={() => { void handleSystemField(sf) }}
 						>
-							<span className="nb-menu-item-icon">{sf === 'ctime' ? '🕓' : '🖊'}</span>
+							<span className="nb-menu-item-icon">{sf === 'ctime' ? <IconClock /> : <IconPen />}</span>
 							<span>{label}</span>
 						</button>
 					))}
@@ -1368,11 +1348,11 @@ export function ColumnHeader({ col, schema, onUpdateSchema, onRenameColumn, onCh
 
 					<div className="nb-menu-separator" />
 					<button className="nb-menu-item" onClick={() => { void handleHide() }}>
-						<span className="nb-menu-item-icon">👁</span>
+						<span className="nb-menu-item-icon"><IconEye /></span>
 						<span>{t('hide_field')}</span>
 					</button>
 					<button className="nb-menu-item nb-menu-item--danger" onClick={() => { void handleDelete() }}>
-						<span className="nb-menu-item-icon">🗑</span>
+						<span className="nb-menu-item-icon"><IconTrash /></span>
 						<span>{t('delete_field')}</span>
 					</button>
 				</div>

--- a/src/components/DatabaseBoard.tsx
+++ b/src/components/DatabaseBoard.tsx
@@ -1,5 +1,5 @@
 import { TFile } from 'obsidian'
-import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { ReactNode, Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
 import {
@@ -7,9 +7,10 @@ import {
 } from '../types'
 import {
 	ActiveFilter, applyFilters, applySorts,
-	getColumnIconStatic, getDefaultOperator,
+	getDefaultOperator,
 	getCardConditionalStyle,
 } from './filter-utils'
+import { getColumnIcon, IconFile, IconCopy, IconTrash } from './icons'
 import { FilterPillsRow } from './FilterPillsRow'
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
@@ -510,7 +511,7 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 	// Debounced: typing a filter value must not persist per keystroke (#60)
 	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
-	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
+	const addFilter = (columnId: string, columnName: string, icon: ReactNode, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]
 		setActiveFilters(next); void saveActivePills(next); setFilterMenuOpen(false)
 	}
@@ -577,7 +578,7 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 				{config.schema.filter(c => c.id !== groupByCol?.id && c.type !== 'title').map(col => (
 					<label key={col.id} className="nb-field-row">
 						<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-						<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+						<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 						<span className="nb-field-name">{col.name}</span>
 					</label>
 				))}
@@ -589,18 +590,18 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 						className={`nb-menu-item${activeView.groupByColumnId === col.id ? ' nb-menu-item--active' : ''}`}
 						onClick={() => { void saveView({ ...activeView, groupByColumnId: col.id }); setGroupByMenuOpen(false) }}
 					>
-						<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 						<span>{col.name}</span>
 					</button>
 				))}
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
-				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), '📄', 'title')}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 				</button>
 				{config.schema.map(col => (
-					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-						<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 						<span>{col.name}</span>
 					</button>
 				))}
@@ -631,7 +632,7 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 							{config.schema.filter(c => c.id !== groupByCol?.id && c.type !== 'title').map(col => (
 								<label key={col.id} className="nb-field-row">
 									<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-									<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+									<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 									<span className="nb-field-name">{col.name}</span>
 								</label>
 							))}
@@ -653,7 +654,7 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 									className={`nb-menu-item${activeView.groupByColumnId === col.id ? ' nb-menu-item--active' : ''}`}
 									onClick={() => { void saveView({ ...activeView, groupByColumnId: col.id }); setGroupByMenuOpen(false) }}
 								>
-									<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 									<span>{col.name}</span>
 								</button>
 							))}
@@ -700,12 +701,12 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 					{filterMenuOpen && (
 						<div className="nb-fields-dropdown nb-filter-menu-dropdown">
 							<div className="nb-fields-dropdown-label">{t('filter_by')}</div>
-							<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), '📄', 'title')}>
-								<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+							<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+								<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 							</button>
 							{config.schema.map(col => (
-								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-									<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 									<span>{col.name}</span>
 								</button>
 							))}
@@ -927,14 +928,14 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 			{/* Context menu (long-press mobile / right-click desktop) */}
 			<BottomSheet open={contextMenuFile !== null} onClose={() => setContextMenuFile(null)} title={contextMenuFile?.basename ?? ''}>
 				<button className="nb-menu-item" onClick={() => { if (contextMenuFile) { void app.workspace.getLeaf().openFile(contextMenuFile) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('open_note')}</span>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('open_note')}</span>
 				</button>
 				<button className="nb-menu-item" onClick={() => { if (contextMenuFile) { void manager.duplicateNotes([contextMenuFile]) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">📋</span><span>{t('duplicate_note')}</span>
+					<span className="nb-menu-item-icon"><IconCopy /></span><span>{t('duplicate_note')}</span>
 				</button>
 				<div className="nb-menu-separator" />
 				<button className="nb-menu-item nb-menu-item--danger" onClick={() => { if (contextMenuFile) { void manager.deleteNotes([contextMenuFile]) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">🗑</span><span>{t('delete_note')}</span>
+					<span className="nb-menu-item-icon"><IconTrash /></span><span>{t('delete_note')}</span>
 				</button>
 			</BottomSheet>
 		</div>

--- a/src/components/DatabaseCalendar.tsx
+++ b/src/components/DatabaseCalendar.tsx
@@ -1,5 +1,5 @@
 import { TFile } from 'obsidian'
-import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { ReactNode, Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
 import {
@@ -7,8 +7,9 @@ import {
 } from '../types'
 import {
 	ActiveFilter, applyFilters,
-	getColumnIconStatic, getDefaultOperator,
+	getDefaultOperator,
 } from './filter-utils'
+import { getColumnIcon, IconFile, IconCalendar, IconPlus, IconCopy, IconTrash } from './icons'
 import { FilterPillsRow } from './FilterPillsRow'
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
@@ -287,7 +288,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 	// Debounced: typing a filter value must not persist per keystroke (#60)
 	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
-	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
+	const addFilter = (columnId: string, columnName: string, icon: ReactNode, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]
 		setActiveFilters(next); void saveActivePills(next); setFilterMenuOpen(false)
 	}
@@ -414,7 +415,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 						className={`nb-menu-item${activeView.calendarDateField === col.id ? ' nb-menu-item--active' : ''}`}
 						onClick={() => { void saveView({ ...activeView, calendarDateField: col.id }); setDateFieldMenuOpen(false) }}
 					>
-						<span className="nb-menu-item-icon">📅</span>
+						<span className="nb-menu-item-icon"><IconCalendar /></span>
 						<span>{col.name}</span>
 					</button>
 				))}
@@ -423,18 +424,18 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 				{config.schema.map(col => (
 					<label key={col.id} className="nb-field-row">
 						<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-						<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+						<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 						<span className="nb-field-name">{col.name}</span>
 					</label>
 				))}
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
-				<button className="nb-menu-item" onClick={() => addFilter('_title', 'Nome', '📄', 'title')}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 				</button>
 				{config.schema.map(col => (
-					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-						<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 						<span>{col.name}</span>
 					</button>
 				))}
@@ -483,7 +484,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 									className={`nb-menu-item${activeView.calendarDateField === col.id ? ' nb-menu-item--active' : ''}`}
 									onClick={() => { void saveView({ ...activeView, calendarDateField: col.id }); setDateFieldMenuOpen(false) }}
 								>
-									<span className="nb-menu-item-icon">📅</span>
+									<span className="nb-menu-item-icon"><IconCalendar /></span>
 									<span>{col.name}</span>
 								</button>
 							))}
@@ -502,7 +503,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 							{config.schema.map(col => (
 								<label key={col.id} className="nb-field-row">
 									<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-									<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+									<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 									<span className="nb-field-name">{col.name}</span>
 								</label>
 							))}
@@ -555,12 +556,12 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 					{filterMenuOpen && (
 						<div className="nb-fields-dropdown nb-filter-menu-dropdown">
 							<div className="nb-fields-dropdown-label">{t('filter_by')}</div>
-							<button className="nb-menu-item" onClick={() => addFilter('_title', 'Nome', '📄', 'title')}>
-								<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+							<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+								<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 							</button>
 							{config.schema.map(col => (
-								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-									<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 									<span>{col.name}</span>
 								</button>
 							))}
@@ -823,7 +824,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 			<BottomSheet open={expandedDay !== null} onClose={() => setExpandedDay(null)} title={expandedDay ?? ''}>
 				{(expandedDay !== null ? (rowsByDate.get(expandedDay) ?? []) : []).map(row => (
 					<button key={row._file.path} className="nb-menu-item" onClick={() => { void app.workspace.getLeaf().openFile(row._file); setExpandedDay(null) }}>
-						<span className="nb-menu-item-icon">📄</span><span>{row._title}</span>
+						<span className="nb-menu-item-icon"><IconFile /></span><span>{row._title}</span>
 					</button>
 				))}
 			</BottomSheet>
@@ -835,20 +836,20 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 					const dayRows = rowsByDate.get(dayKey) ?? []
 					return <>
 						<button className="nb-menu-item" onClick={() => { void handleDayClick(actionDay.year, actionDay.month, actionDay.day); setActionDay(null) }}>
-							<span className="nb-menu-item-icon">➕</span><span>{t('add_card')}</span>
+							<span className="nb-menu-item-icon"><IconPlus /></span><span>{t('add_card')}</span>
 						</button>
 						{dayRows.length > 0 && <div className="nb-menu-separator" />}
 						{dayRows.map(row => (
 							<Fragment key={row._file.path}>
 								<button className="nb-menu-item" onClick={() => { void app.workspace.getLeaf().openFile(row._file); setActionDay(null) }}>
-									<span className="nb-menu-item-icon">📄</span><span>{row._title}</span>
+									<span className="nb-menu-item-icon"><IconFile /></span><span>{row._title}</span>
 								</button>
 								<div className="nb-cal-day-actions">
 									<button className="nb-menu-item" onClick={() => { void manager.duplicateNotes([row._file]); setActionDay(null) }}>
-										<span className="nb-menu-item-icon">📋</span><span>{t('duplicate_note')}</span>
+										<span className="nb-menu-item-icon"><IconCopy /></span><span>{t('duplicate_note')}</span>
 									</button>
 									<button className="nb-menu-item nb-menu-item--danger" onClick={() => { void manager.deleteNotes([row._file]); setActionDay(null) }}>
-										<span className="nb-menu-item-icon">🗑</span><span>{t('delete_note')}</span>
+										<span className="nb-menu-item-icon"><IconTrash /></span><span>{t('delete_note')}</span>
 									</button>
 								</div>
 							</Fragment>

--- a/src/components/DatabaseCharts.tsx
+++ b/src/components/DatabaseCharts.tsx
@@ -1,5 +1,5 @@
 import { TFile } from 'obsidian'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
@@ -8,8 +8,9 @@ import {
 } from '../types'
 import {
 	ActiveFilter, applyFilters, applySorts,
-	getColumnIconStatic, getDefaultOperator,
+	getDefaultOperator,
 } from './filter-utils'
+import { getColumnIcon, IconFile } from './icons'
 import { FilterPillsRow } from './FilterPillsRow'
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
@@ -579,7 +580,7 @@ export function DatabaseCharts({ dbFile, manager, externalView, onViewChange }: 
 	// Debounced: typing a filter value must not persist per keystroke (#60)
 	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
-	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
+	const addFilter = (columnId: string, columnName: string, icon: ReactNode, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]
 		setActiveFilters(next); void saveActivePills(next); setFilterMenuOpen(false)
 	}
@@ -716,12 +717,12 @@ export function DatabaseCharts({ dbFile, manager, externalView, onViewChange }: 
 				{configContent}
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
-				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), '📄', 'title')}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 				</button>
 				{config.schema.map(col => (
-					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-						<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 						<span>{col.name}</span>
 					</button>
 				))}
@@ -808,12 +809,12 @@ export function DatabaseCharts({ dbFile, manager, externalView, onViewChange }: 
 					{filterMenuOpen && (
 						<div className="nb-fields-dropdown nb-filter-menu-dropdown">
 							<div className="nb-fields-dropdown-label">{t('filter_by')}</div>
-							<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), '📄', 'title')}>
-								<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+							<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+								<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 							</button>
 							{config.schema.map(col => (
-								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-									<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 									<span>{col.name}</span>
 								</button>
 							))}

--- a/src/components/DatabaseGallery.tsx
+++ b/src/components/DatabaseGallery.tsx
@@ -1,5 +1,5 @@
 import { TFile } from 'obsidian'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
@@ -8,9 +8,10 @@ import {
 } from '../types'
 import {
 	ActiveFilter, applyFilters, applySorts,
-	getColumnIconStatic, getDefaultOperator,
+	getDefaultOperator,
 	getCardConditionalStyle,
 } from './filter-utils'
+import { getColumnIcon, IconFile } from './icons'
 import { FilterPillsRow } from './FilterPillsRow'
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
@@ -151,7 +152,7 @@ const GalleryCard = React.memo(function GalleryCard({
 				</div>
 			) : (
 				<div className="nb-gallery-cover nb-gallery-cover--empty">
-					<span className="nb-gallery-cover-icon">📄</span>
+					<span className="nb-gallery-cover-icon"><IconFile /></span>
 				</div>
 			)}
 			<div className="nb-gallery-body">
@@ -292,7 +293,7 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 	// Debounced: typing a filter value must not persist per keystroke (#60)
 	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
-	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
+	const addFilter = (columnId: string, columnName: string, icon: ReactNode, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]
 		setActiveFilters(next); void saveActivePills(next); setFilterMenuOpen(false)
 	}
@@ -350,7 +351,7 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 				{config.schema.map(col => (
 					<label key={col.id} className="nb-field-row">
 						<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-						<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+						<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 						<span className="nb-field-name">{col.name}</span>
 					</label>
 				))}
@@ -369,18 +370,18 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 						className={`nb-menu-item${activeView.galleryCoverField === col.id ? ' nb-menu-item--active' : ''}`}
 						onClick={() => { void saveView({ ...activeView, galleryCoverField: col.id }); setCoverMenuOpen(false) }}
 					>
-						<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 						<span>{col.name}</span>
 					</button>
 				))}
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
-				<button className="nb-menu-item" onClick={() => addFilter('_title', 'Nome', '📄', 'title')}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 				</button>
 				{config.schema.map(col => (
-					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-						<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 						<span>{col.name}</span>
 					</button>
 				))}
@@ -446,7 +447,7 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 							{config.schema.map(col => (
 								<label key={col.id} className="nb-field-row">
 									<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-									<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+									<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 									<span className="nb-field-name">{col.name}</span>
 								</label>
 							))}
@@ -475,7 +476,7 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 									className={`nb-menu-item${activeView.galleryCoverField === col.id ? ' nb-menu-item--active' : ''}`}
 									onClick={() => { void saveView({ ...activeView, galleryCoverField: col.id }); setCoverMenuOpen(false) }}
 								>
-									<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 									<span>{col.name}</span>
 								</button>
 							))}
@@ -532,12 +533,12 @@ export function DatabaseGallery({ dbFile, manager, externalView, onViewChange }:
 					{filterMenuOpen && (
 						<div className="nb-fields-dropdown nb-filter-menu-dropdown">
 							<div className="nb-fields-dropdown-label">{t('filter_by')}</div>
-							<button className="nb-menu-item" onClick={() => addFilter('_title', 'Nome', '📄', 'title')}>
-								<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+							<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+								<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 							</button>
 							{config.schema.map(col => (
-								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-									<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 									<span>{col.name}</span>
 								</button>
 							))}

--- a/src/components/DatabaseList.tsx
+++ b/src/components/DatabaseList.tsx
@@ -1,5 +1,5 @@
 import { TFile } from 'obsidian'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
@@ -8,9 +8,10 @@ import {
 } from '../types'
 import {
 	ActiveFilter, applyFilters, applySorts,
-	getColumnIconStatic, getDefaultOperator,
+	getDefaultOperator,
 	getCardConditionalStyle,
 } from './filter-utils'
+import { getColumnIcon, IconFile, IconCopy, IconTrash } from './icons'
 import { FilterPillsRow } from './FilterPillsRow'
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
@@ -146,7 +147,7 @@ const ListRow = React.memo(function ListRow({
 					{isExpanded ? '▼' : '▶'}
 				</button>
 			)}
-			<span className="nb-list-row-icon">📄</span>
+			<span className="nb-list-row-icon"><IconFile /></span>
 			<span className="nb-list-row-title">{row._title}</span>
 			{relPath ? <span className="nb-folder-path" style={{ marginLeft: 4 }}>{relPath}</span> : null}
 			{visibleCols.length > 0 && (
@@ -240,7 +241,7 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 	// Debounced: typing a filter value must not persist per keystroke (#60)
 	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
-	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
+	const addFilter = (columnId: string, columnName: string, icon: ReactNode, columnType: string) => {
 		const next: ActiveFilter[] = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' }]
 		setActiveFilters(next); void saveActivePills(next); setFilterMenuOpen(false)
 	}
@@ -337,18 +338,18 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 				{config.schema.map(col => (
 					<label key={col.id} className="nb-field-row">
 						<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-						<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+						<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 						<span className="nb-field-name">{col.name}</span>
 					</label>
 				))}
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
-				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), '📄', 'title')}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 				</button>
 				{config.schema.map(col => (
-					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-						<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 						<span>{col.name}</span>
 					</button>
 				))}
@@ -413,7 +414,7 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 							{config.schema.map(col => (
 								<label key={col.id} className="nb-field-row">
 									<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-									<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+									<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 									<span className="nb-field-name">{col.name}</span>
 								</label>
 							))}
@@ -441,12 +442,12 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 					{filterMenuOpen && (
 						<div className="nb-fields-dropdown nb-filter-menu-dropdown">
 							<div className="nb-fields-dropdown-label">{t('filter_by')}</div>
-							<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), '📄', 'title')}>
-								<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+							<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+								<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 							</button>
 							{config.schema.map(col => (
-								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-									<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span>
+								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 									<span>{col.name}</span>
 								</button>
 							))}
@@ -534,14 +535,14 @@ export function DatabaseList({ dbFile, manager, externalView, onViewChange }: Da
 			{/* Context menu (long-press mobile / right-click desktop) */}
 			<BottomSheet open={contextMenuFile !== null} onClose={() => setContextMenuFile(null)} title={contextMenuFile?.basename ?? ''}>
 				<button className="nb-menu-item" onClick={() => { if (contextMenuFile) { void app.workspace.getLeaf().openFile(contextMenuFile) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('open_note')}</span>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('open_note')}</span>
 				</button>
 				<button className="nb-menu-item" onClick={() => { if (contextMenuFile) { void manager.duplicateNotes([contextMenuFile]) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">📋</span><span>{t('duplicate_note')}</span>
+					<span className="nb-menu-item-icon"><IconCopy /></span><span>{t('duplicate_note')}</span>
 				</button>
 				<div className="nb-menu-separator" />
 				<button className="nb-menu-item nb-menu-item--danger" onClick={() => { if (contextMenuFile) { void manager.deleteNotes([contextMenuFile]) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">🗑</span><span>{t('delete_note')}</span>
+					<span className="nb-menu-item-icon"><IconTrash /></span><span>{t('delete_note')}</span>
 				</button>
 			</BottomSheet>
 		</div>

--- a/src/components/DatabaseRoot.tsx
+++ b/src/components/DatabaseRoot.tsx
@@ -1,10 +1,11 @@
 import { TFile } from 'obsidian'
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import { Fragment, ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
 import { DatabaseSettingsModal } from '../database-settings-modal'
 import { DatabaseConfig, DEFAULT_DATABASE_CONFIG, DEFAULT_VIEW, EmbedState, ViewConfig } from '../types'
 import { applyFilters } from './filter-utils'
+import { IconCalendar, IconChart, IconSettings } from './icons'
 import { restoreFilterPills } from '../hooks/useDatabaseRows'
 import { evaluateFormulas } from '../formula-engine'
 import { DatabaseTable } from './DatabaseTable'
@@ -27,7 +28,7 @@ interface DatabaseRootProps {
 	onEmbedStateChange?: (state: EmbedState) => Promise<void>
 }
 
-const VIEW_ICONS: Record<string, string> = { table: '⊞', list: '≡', board: '▦', gallery: '⊟', calendar: '📅', timeline: '▬', chart: '📊' }
+const VIEW_ICONS: Record<string, ReactNode> = { table: '⊞', list: '≡', board: '▦', gallery: '⊟', calendar: <IconCalendar />, timeline: '▬', chart: <IconChart /> }
 const VIEW_LABELS = () => ({ table: t('view_table'), list: t('view_list'), board: t('view_board'), gallery: t('view_gallery'), calendar: t('view_calendar'), timeline: t('view_timeline'), chart: t('view_chart') })
 
 export function DatabaseRoot({
@@ -452,7 +453,7 @@ export function DatabaseRoot({
 						}, manager, dbFile, restrictToPaths).open()
 					}}
 				>
-					⚙
+					<IconSettings />
 				</button>
 			</div>
 			{activeView.type === 'table'

--- a/src/components/DatabaseTable.tsx
+++ b/src/components/DatabaseTable.tsx
@@ -36,6 +36,7 @@ import { useDatabaseRows } from '../hooks/useDatabaseRows'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { ColumnHeader } from './ColumnHeader'
+import { getColumnIcon, IconCopy, IconFile, IconFolder, IconPin, IconTrash, IconZap } from './icons'
 import { CellRenderer, CellContext } from './cells/CellRenderer'
 import { FolderPickerModal } from '../folder-picker-modal'
 import { t } from '../i18n'
@@ -284,20 +285,12 @@ function validateTypeChange(rows: NoteRow[], columnId: string, fromType: ColumnT
 
 // ── Helpers estáticos ────────────────────────────────────────────────────────
 
-function getColumnIconStatic(type: string): string {
-	const icons: Record<string, string> = {
-		title: '📄', text: 'Aa', number: '#', select: '◉',
-		multiselect: '◈', date: '📅', checkbox: '☑', formula: 'ƒ', relation: '🔗', lookup: '↗',
-	}
-	return icons[type] ?? '·'
-}
-
 interface ActiveFilter {
 	id: string
 	columnId: string
 	columnName: string
 	columnType: string
-	icon: string
+	icon: ReactNode
 	operator: FilterOperator
 	value: string
 	conjunction: 'and' | 'or'
@@ -632,7 +625,7 @@ function SortableTh({ id, size, children, stickyLeft, isLastPinned, isPinned, on
 						onClick={e => { e.stopPropagation(); onTogglePin() }}
 						title={isPinned ? t('tooltip_unpin_column') : t('tooltip_pin_column')}
 					>
-						📌
+						<IconPin />
 					</button>
 				)}
 			</div>
@@ -1062,7 +1055,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 				const sorted = column.getIsSorted()
 				return (
 					<div className="nb-header-title">
-						<span>📄</span>
+						<span><IconFile /></span>
 						<span>{t('name_column')}</span>
 						<button
 							className={`nb-sort-btn ${sorted ? 'nb-sort-btn--sorted' : ''}`}
@@ -1522,8 +1515,6 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 
 		// ── Filtros ───────────────────────────────────────────────────────────────
 
-	const getColumnIcon = getColumnIconStatic
-
 	const saveActivePillsNow = useCallback(async (filters: { columnId: string }[]) => {
 		const pills = (filters as ActiveFilter[]).map(f => ({ id: f.id, columnId: f.columnId, operator: f.operator, value: f.value, conjunction: f.conjunction }))
 		await saveView({ ...activeView, activePills: pills })
@@ -1541,7 +1532,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 		void saveActivePills(next)
 	}
 
-	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
+	const addFilter = (columnId: string, columnName: string, icon: ReactNode, columnType: string) => {
 		const filterId = crypto.randomUUID()
 		const next: ActiveFilter[] = [...activeFilters, { id: filterId, columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' as const }]
 		setActiveFilters(next)
@@ -1754,13 +1745,13 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 			</BottomSheet>
 			<BottomSheet open={actionsMenuOpen} onClose={() => setActionsMenuOpen(false)} title={t('actions')}>
 				<button className="nb-menu-item" onClick={() => { void handleDeleteSelected() }} disabled={table.getSelectedRowModel().rows.length === 0}>
-					<span className="nb-menu-item-icon">🗑</span><span>{t('delete_selected')}</span>
+					<span className="nb-menu-item-icon"><IconTrash /></span><span>{t('delete_selected')}</span>
 				</button>
 				<button className="nb-menu-item" onClick={handleMoveSelected} disabled={table.getSelectedRowModel().rows.length === 0}>
-					<span className="nb-menu-item-icon">📁</span><span>{t('move_selected')}</span>
+					<span className="nb-menu-item-icon"><IconFolder /></span><span>{t('move_selected')}</span>
 				</button>
 				<button className="nb-menu-item" onClick={() => { void handleDuplicateSelected() }} disabled={table.getSelectedRowModel().rows.length === 0}>
-					<span className="nb-menu-item-icon">📋</span><span>{t('duplicate_selected')}</span>
+					<span className="nb-menu-item-icon"><IconCopy /></span><span>{t('duplicate_selected')}</span>
 				</button>
 				<div className="nb-menu-separator" />
 				<button className="nb-menu-item" onClick={handleExportCsv}>
@@ -1772,8 +1763,8 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 				<input ref={csvInputRef} type="file" accept=".csv" style={{ display: 'none' }} onChange={e => { void handleImportCsv(e) }} />
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
-				<button className="nb-menu-item" onClick={() => addFilter('_title', 'Nome', '📄', 'title')}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 				</button>
 				{config.schema.map(col => (
 					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
@@ -1935,17 +1926,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 											: col.visible}
 										onChange={() => { void toggleFieldVisibility(col.id) }}
 									/>
-									<span className="nb-field-icon">{
-										col.type === 'text' ? 'Aa' :
-										col.type === 'number' ? '#' :
-										col.type === 'select' ? '◉' :
-										col.type === 'multiselect' ? '◈' :
-										col.type === 'date' ? '📅' :
-										col.type === 'checkbox' ? '☑' :
-										col.type === 'lookup' ? '↗' :
-										col.type === 'relation' ? '🔗' :
-									col.type === 'formula' ? 'ƒ' : '·'
-									}</span>
+									<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 									<span className="nb-field-name">{col.name}</span>
 								</label>
 							))}
@@ -1975,7 +1956,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 								onClick={() => { void handleDeleteSelected() }}
 								disabled={table.getSelectedRowModel().rows.length === 0}
 							>
-								<span className="nb-menu-item-icon">🗑</span>
+								<span className="nb-menu-item-icon"><IconTrash /></span>
 								<span>{t('delete_selected')}</span>
 							</button>
 							<button
@@ -1983,7 +1964,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 								onClick={handleMoveSelected}
 								disabled={table.getSelectedRowModel().rows.length === 0}
 							>
-								<span className="nb-menu-item-icon">📁</span>
+								<span className="nb-menu-item-icon"><IconFolder /></span>
 								<span>{t('move_selected')}</span>
 							</button>
 							<button
@@ -1991,7 +1972,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 								onClick={() => { void handleDuplicateSelected() }}
 								disabled={table.getSelectedRowModel().rows.length === 0}
 							>
-								<span className="nb-menu-item-icon">📋</span>
+								<span className="nb-menu-item-icon"><IconCopy /></span>
 								<span>{t('duplicate_selected')}</span>
 							</button>
 							<div className="nb-menu-separator" />
@@ -2033,10 +2014,10 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 							<div className="nb-fields-dropdown-label">{t('filter_by')}</div>
 							<button
 								className="nb-menu-item"
-								onClick={() => addFilter('_title', 'Nome', '📄', 'title')}
+								onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}
 								
 							>
-								<span className="nb-menu-item-icon">📄</span>
+								<span className="nb-menu-item-icon"><IconFile /></span>
 								<span>{t('name_column')}</span>
 							</button>
 							{config.schema.map(col => (
@@ -2052,7 +2033,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 							))}
 							<div className="nb-menu-separator" />
 							<button className="nb-menu-item" onClick={() => setFilterMenuOpen(false)}>
-								<span className="nb-menu-item-icon">⚡</span>
+								<span className="nb-menu-item-icon"><IconZap /></span>
 								<span>{t('add_filter_advanced')}</span>
 							</button>
 						</div>
@@ -2316,7 +2297,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 																	className={`nb-pin-btn${pinnedColumnId === '_title' ? ' nb-pin-btn--active' : ''}`}
 																	onClick={() => { void handleTogglePin('_title') }}
 																	title={pinnedColumnId === '_title' ? t('tooltip_unpin_column') : t('tooltip_pin_column')}
-																>📌</button>
+																><IconPin /></button>
 															</div>
 															<ResizeHandle onResize={w => { void handleColumnResize('_title', w) }} onAutoFit={() => { void handleColumnAutoFit('_title') }} />
 														</th>
@@ -2442,10 +2423,10 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 			{/* Context menu (long-press mobile / right-click desktop) */}
 			<BottomSheet open={contextMenuFile !== null} onClose={() => setContextMenuFile(null)} title={contextMenuFile?.basename ?? ''}>
 				<button className="nb-menu-item" onClick={() => { if (contextMenuFile) { void app.workspace.getLeaf().openFile(contextMenuFile) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('open_note')}</span>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('open_note')}</span>
 				</button>
 				<button className="nb-menu-item" onClick={() => { if (contextMenuFile) { void manager.duplicateNotes([contextMenuFile]) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">📋</span><span>{t('duplicate_note')}</span>
+					<span className="nb-menu-item-icon"><IconCopy /></span><span>{t('duplicate_note')}</span>
 				</button>
 				{hierarchyCol && contextMenuFile && (hierarchyMap?.get(contextMenuFile.path)?.depth ?? 0) < 3 && (
 					<button className="nb-menu-item" onClick={() => { void handleAddSubRow(contextMenuFile.basename); setContextMenuFile(null) }}>
@@ -2454,7 +2435,7 @@ export function DatabaseTable({ dbFile, manager, externalView, onViewChange }: D
 				)}
 				<div className="nb-menu-separator" />
 				<button className="nb-menu-item nb-menu-item--danger" onClick={() => { if (contextMenuFile) { void manager.deleteNotes([contextMenuFile]) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">🗑</span><span>{t('delete_note')}</span>
+					<span className="nb-menu-item-icon"><IconTrash /></span><span>{t('delete_note')}</span>
 				</button>
 			</BottomSheet>
 		</div>

--- a/src/components/DatabaseTimeline.tsx
+++ b/src/components/DatabaseTimeline.tsx
@@ -1,5 +1,5 @@
 import { TFile } from 'obsidian'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
 import {
@@ -7,8 +7,9 @@ import {
 } from '../types'
 import {
 	ActiveFilter, applyFilters, applySorts,
-	getColumnIconStatic, getDefaultOperator,
+	getDefaultOperator,
 } from './filter-utils'
+import { getColumnIcon, IconFile, IconCalendar, IconCopy, IconTrash } from './icons'
 import { FilterPillsRow } from './FilterPillsRow'
 import { useDebouncedCallback } from '../hooks/useDebouncedCallback'
 import { t } from '../i18n'
@@ -377,7 +378,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 	// Debounced: typing a filter value must not persist per keystroke (#60)
 	const saveActivePills = useDebouncedCallback(saveActivePillsNow, 400)
 
-	const addFilter = (columnId: string, columnName: string, icon: string, columnType: string) => {
+	const addFilter = (columnId: string, columnName: string, icon: ReactNode, columnType: string) => {
 		const next = [...activeFilters, { id: crypto.randomUUID(), columnId, columnName, columnType, icon, operator: getDefaultOperator(columnType), value: '', conjunction: 'and' as const }]
 		setActiveFilters(next); void saveActivePills(next); setFilterMenuOpen(false)
 	}
@@ -436,7 +437,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 						{config.schema.filter(c => c.type === 'date').map(col => (
 							<button key={col.id} className={`nb-menu-item${activeView[valueKey] === col.id ? ' nb-menu-item--active' : ''}`}
 								onClick={() => { void saveView({ ...activeView, [valueKey]: col.id }); setOpen(false) }}>
-								<span className="nb-menu-item-icon">📅</span><span>{col.name}</span>
+								<span className="nb-menu-item-icon"><IconCalendar /></span><span>{col.name}</span>
 							</button>
 						))}
 					</div>
@@ -479,7 +480,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 				{config.schema.filter(c => c.type === 'date').map(col => (
 					<button key={col.id} className={`nb-menu-item${activeView.timelineStartField === col.id ? ' nb-menu-item--active' : ''}`}
 						onClick={() => { void saveView({ ...activeView, timelineStartField: col.id }); setStartMenuOpen(false) }}>
-						<span className="nb-menu-item-icon">📅</span><span>{col.name}</span>
+						<span className="nb-menu-item-icon"><IconCalendar /></span><span>{col.name}</span>
 					</button>
 				))}
 			</BottomSheet>
@@ -491,7 +492,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 				{config.schema.filter(c => c.type === 'date').map(col => (
 					<button key={col.id} className={`nb-menu-item${activeView.timelineEndField === col.id ? ' nb-menu-item--active' : ''}`}
 						onClick={() => { void saveView({ ...activeView, timelineEndField: col.id }); setEndMenuOpen(false) }}>
-						<span className="nb-menu-item-icon">📅</span><span>{col.name}</span>
+						<span className="nb-menu-item-icon"><IconCalendar /></span><span>{col.name}</span>
 					</button>
 				))}
 			</BottomSheet>
@@ -503,7 +504,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 				{config.schema.filter(c => c.type === 'select' || c.type === 'status').map(col => (
 					<button key={col.id} className={`nb-menu-item${activeView.timelineGroupByField === col.id ? ' nb-menu-item--active' : ''}`}
 						onClick={() => { void saveView({ ...activeView, timelineGroupByField: col.id }); setGroupMenuOpen(false) }}>
-						<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span><span>{col.name}</span>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span><span>{col.name}</span>
 					</button>
 				))}
 			</BottomSheet>
@@ -511,18 +512,18 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 				{config.schema.map(col => (
 					<label key={col.id} className="nb-field-row">
 						<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-						<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+						<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 						<span className="nb-field-name">{col.name}</span>
 					</label>
 				))}
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
-				<button className="nb-menu-item" onClick={() => addFilter('_title', 'Nome', '📄', 'title')}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 				</button>
 				{config.schema.map(col => (
-					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-						<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span><span>{col.name}</span>
+					<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span><span>{col.name}</span>
 					</button>
 				))}
 			</BottomSheet>
@@ -565,7 +566,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 							{config.schema.filter(c => c.type === 'select' || c.type === 'status').map(col => (
 								<button key={col.id} className={`nb-menu-item${activeView.timelineGroupByField === col.id ? ' nb-menu-item--active' : ''}`}
 									onClick={() => { void saveView({ ...activeView, timelineGroupByField: col.id }); setGroupMenuOpen(false) }}>
-									<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span><span>{col.name}</span>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span><span>{col.name}</span>
 								</button>
 							))}
 						</div>
@@ -581,7 +582,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 							{config.schema.map(col => (
 								<label key={col.id} className="nb-field-row">
 									<input type="checkbox" className="nb-field-checkbox" checked={col.visible && !activeView.hiddenColumns.includes(col.id)} onChange={() => { void toggleFieldVisibility(col.id) }} />
-									<span className="nb-field-icon">{getColumnIconStatic(col.type)}</span>
+									<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 									<span className="nb-field-name">{col.name}</span>
 								</label>
 							))}
@@ -631,12 +632,12 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 					{filterMenuOpen && (
 						<div className="nb-fields-dropdown nb-filter-menu-dropdown">
 							<div className="nb-fields-dropdown-label">{t('filter_by')}</div>
-							<button className="nb-menu-item" onClick={() => addFilter('_title', 'Nome', '📄', 'title')}>
-								<span className="nb-menu-item-icon">📄</span><span>{t('name_column')}</span>
+							<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
+								<span className="nb-menu-item-icon"><IconFile /></span><span>{t('name_column')}</span>
 							</button>
 							{config.schema.map(col => (
-								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIconStatic(col.type), col.type)}>
-									<span className="nb-menu-item-icon">{getColumnIconStatic(col.type)}</span><span>{col.name}</span>
+								<button key={col.id} className="nb-menu-item" onClick={() => addFilter(col.id, col.name, getColumnIcon(col.type), col.type)}>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span><span>{col.name}</span>
 								</button>
 							))}
 						</div>
@@ -778,14 +779,14 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 			{/* Bar context menu (mobile tap) */}
 			<BottomSheet open={contextMenuFile !== null} onClose={() => setContextMenuFile(null)} title={contextMenuFile?.basename ?? ''}>
 				<button className="nb-menu-item" onClick={() => { if (contextMenuFile) { void app.workspace.getLeaf().openFile(contextMenuFile) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">📄</span><span>{t('open_note')}</span>
+					<span className="nb-menu-item-icon"><IconFile /></span><span>{t('open_note')}</span>
 				</button>
 				<button className="nb-menu-item" onClick={() => { if (contextMenuFile) { void manager.duplicateNotes([contextMenuFile]) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">📋</span><span>{t('duplicate_note')}</span>
+					<span className="nb-menu-item-icon"><IconCopy /></span><span>{t('duplicate_note')}</span>
 				</button>
 				<div className="nb-menu-separator" />
 				<button className="nb-menu-item nb-menu-item--danger" onClick={() => { if (contextMenuFile) { void manager.deleteNotes([contextMenuFile]) } setContextMenuFile(null) }}>
-					<span className="nb-menu-item-icon">🗑</span><span>{t('delete_note')}</span>
+					<span className="nb-menu-item-icon"><IconTrash /></span><span>{t('delete_note')}</span>
 				</button>
 			</BottomSheet>
 		</div>

--- a/src/components/cells/CellRenderer.tsx
+++ b/src/components/cells/CellRenderer.tsx
@@ -4,6 +4,7 @@ import { TFile } from 'obsidian'
 import { ColumnSchema, NumberFormat, SelectOption } from '../../types'
 import { useApp } from '../../context'
 import { t } from '../../i18n'
+import { IconClock, IconFilm, IconMusic, IconPhone } from '../icons'
 
 interface CellProps {
 	col: ColumnSchema
@@ -515,7 +516,7 @@ function PhoneCell({ value, isEditing, onStartEdit, onCommit, onCancel }: {
 			{value ? (
 				<span className="nb-cell-link-wrapper">
 					<span className="nb-cell-link" onClick={openTel}>{applyPhoneMask(value)}</span>
-					<span className="nb-cell-link-icon" onClick={openTel}>📞</span>
+					<span className="nb-cell-link-icon" onClick={openTel}><IconPhone /></span>
 				</span>
 			) : (
 				<span className="nb-cell-empty">—</span>
@@ -1320,7 +1321,7 @@ function DateCell({ value, format, isEditing, onStartEdit, onSave, onClose }: {
 				onClick={e => { e.stopPropagation(); toggleTime() }}
 				title={showTime ? t('calendar_remove_time') : t('calendar_add_time')}
 			>
-				🕐
+				<IconClock />
 			</button>
 		</div>
 	)
@@ -1660,7 +1661,7 @@ function AudioCell({ col, value, isEditing, onStartEdit, onCommit, onCancel }: {
 								className={`nb-select-option${value === f.path ? ' nb-select-option--active' : ''}`}
 								onClick={e => { e.stopPropagation(); onCommit(f.path) }}
 							>
-								<span>🎵</span>
+								<span><IconMusic /></span>
 								<span>{f.name}</span>
 							</button>
 						))
@@ -1760,7 +1761,7 @@ function VideoCell({ col, value, isEditing, onStartEdit, onCommit, onCancel }: {
 								className={`nb-select-option${value === f.path ? ' nb-select-option--active' : ''}`}
 								onClick={e => { e.stopPropagation(); onCommit(f.path) }}
 							>
-								<span>🎬</span>
+								<span><IconFilm /></span>
 								<span>{f.name}</span>
 							</button>
 						))

--- a/src/components/filter-utils.ts
+++ b/src/components/filter-utils.ts
@@ -8,7 +8,7 @@ export interface ActiveFilter {
 	columnId: string
 	columnName: string
 	columnType: string
-	icon: string
+	icon: React.ReactNode
 	operator: FilterOperator
 	value: string
 	conjunction: 'and' | 'or'
@@ -72,15 +72,6 @@ export function toggleMultiValue(current: string, option: string): string {
 	if (idx >= 0) values.splice(idx, 1)
 	else values.push(option)
 	return values.join(MULTI_VALUE_SEPARATOR)
-}
-
-export function getColumnIconStatic(type: string): string {
-	const icons: Record<string, string> = {
-		title: '📄', text: 'Aa', number: '#', select: '◉',
-		multiselect: '◈', date: '📅', checkbox: '☑', formula: 'ƒ', relation: '🔗', lookup: '↗',
-		image: '🖼', audio: '🎵', video: '🎬',
-	}
-	return icons[type] ?? '·'
 }
 
 /** Local calendar day ("YYYY-MM-DD") of a date value, or null if unparseable. */

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,74 @@
+import React, { ReactNode } from 'react'
+
+// Monochrome UI icons (lucide outlines). Sized 1em so they inherit the font
+// size of the span that previously held an emoji, and stroke currentColor so
+// they follow the theme like every other Obsidian icon.
+const icon = (paths: ReactNode) => {
+	const Icon = () => (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="1em"
+			height="1em"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className="nb-icon"
+			aria-hidden="true"
+		>
+			{paths}
+		</svg>
+	)
+	return Icon
+}
+
+export const IconFile = icon(<><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></>)
+export const IconCalendar = icon(<><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></>)
+export const IconTrash = icon(<><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></>)
+export const IconCopy = icon(<><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></>)
+export const IconLink = icon(<><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></>)
+export const IconMusic = icon(<><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></>)
+export const IconFilm = icon(<><rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18"/><line x1="7" y1="2" x2="7" y2="22"/><line x1="17" y1="2" x2="17" y2="22"/><line x1="2" y1="12" x2="22" y2="12"/><line x1="2" y1="7" x2="7" y2="7"/><line x1="2" y1="17" x2="7" y2="17"/><line x1="17" y1="17" x2="22" y2="17"/><line x1="17" y1="7" x2="22" y2="7"/></>)
+export const IconImage = icon(<><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></>)
+export const IconCheckSquare = icon(<><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></>)
+export const IconMail = icon(<><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></>)
+export const IconPhone = icon(<path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>)
+export const IconPin = icon(<><path d="M12 17v5"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1z"/></>)
+export const IconFolder = icon(<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>)
+export const IconClock = icon(<><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></>)
+export const IconPen = icon(<><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></>)
+export const IconPencil = icon(<path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/>)
+export const IconChart = icon(<><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></>)
+export const IconEye = icon(<><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></>)
+export const IconPlus = icon(<><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></>)
+export const IconZap = icon(<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>)
+export const IconSettings = icon(<><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></>)
+
+// One shared icon per column type. Typographic glyphs (Aa, #, ƒ, Σ…) render
+// monochrome everywhere and stay as text; everything pictorial is an SVG.
+export const COLUMN_TYPE_ICONS: Record<string, ReactNode> = {
+	title:       <IconFile />,
+	text:        'Aa',
+	number:      '#',
+	select:      '◉',
+	multiselect: '◈',
+	date:        <IconCalendar />,
+	checkbox:    <IconCheckSquare />,
+	url:         '↗',
+	email:       <IconMail />,
+	phone:       <IconPhone />,
+	status:      '◎',
+	formula:     'ƒ',
+	relation:    <IconLink />,
+	lookup:      '↗',
+	rollup:      'Σ',
+	image:       <IconImage />,
+	audio:       <IconMusic />,
+	video:       <IconFilm />,
+}
+
+export function getColumnIcon(type: string): ReactNode {
+	return COLUMN_TYPE_ICONS[type] ?? '·'
+}

--- a/src/hooks/useDatabaseRows.ts
+++ b/src/hooks/useDatabaseRows.ts
@@ -5,7 +5,8 @@ import {
 	ColumnSchema, DatabaseConfig, DEFAULT_DATABASE_CONFIG, NoteRow, ViewConfig,
 } from '../types'
 import { evaluateFormulas } from '../formula-engine'
-import { ActiveFilter, getColumnIconStatic } from '../components/filter-utils'
+import { ActiveFilter } from '../components/filter-utils'
+import { getColumnIcon } from '../components/icons'
 import { t } from '../i18n'
 
 const CHUNK_SIZE = 200
@@ -69,7 +70,7 @@ export function restoreFilterPills(
 				columnId: '_title',
 				columnName: t('name_column'),
 				columnType: 'title',
-				icon: '📄',
+				icon: getColumnIcon('title'),
 				operator: p.operator,
 				value: p.value,
 				conjunction: p.conjunction ?? 'and',
@@ -82,7 +83,7 @@ export function restoreFilterPills(
 			columnId: col.id,
 			columnName: col.name,
 			columnType: col.type,
-			icon: getColumnIconStatic(col.type),
+			icon: getColumnIcon(col.type),
 			operator: p.operator,
 			value: p.value,
 			conjunction: p.conjunction ?? 'and',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -498,7 +498,7 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	formula_err_not_implemented: 'Funktion nicht implementiert: $fn()',
 
 	// Plugin
-	plugin_display_name: 'Notion bases',
+	plugin_display_name: 'Notion Bases',
 	no_databases_found: 'Keine Datenbanken gefunden. Verwenden Sie den Befehl "Neue Datenbank erstellen", um eine zu erstellen.',
 
 	// Commands

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -496,7 +496,7 @@ const en = {
 	formula_err_not_implemented: 'Function not implemented: $fn()',
 
 	// Plugin
-	plugin_display_name: 'Notion bases',
+	plugin_display_name: 'Notion Bases',
 	no_databases_found: 'No databases found. Use the "create new database" command to create one.',
 
 	// Commands

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -498,7 +498,7 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	formula_err_not_implemented: 'Función no implementada: $fn()',
 
 	// Plugin
-	plugin_display_name: 'Notion bases',
+	plugin_display_name: 'Notion Bases',
 	no_databases_found: 'No se encontraron bases de datos. Usa el comando "crear nueva base de datos" para crear una.',
 
 	// Commands

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -498,7 +498,7 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	formula_err_not_implemented: 'Fonction non implémentée : $fn()',
 
 	// Plugin
-	plugin_display_name: 'Notion bases',
+	plugin_display_name: 'Notion Bases',
 	no_databases_found: 'Aucune base de données trouvée. Utilisez la commande "créer une nouvelle base de données" pour en créer une.',
 
 	// Commands

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -498,7 +498,7 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	formula_err_not_implemented: '未実装の関数：$fn()',
 
 	// Plugin
-	plugin_display_name: 'Notion bases',
+	plugin_display_name: 'Notion Bases',
 	no_databases_found: 'データベースが見つかりません。「新しいデータベースを作成」コマンドを使用して作成してください。',
 
 	// Commands

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -498,7 +498,7 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	formula_err_not_implemented: 'Função não implementada: $fn()',
 
 	// Plugin
-	plugin_display_name: 'Notion bases',
+	plugin_display_name: 'Notion Bases',
 	no_databases_found: 'Nenhum banco de dados encontrado. Use o comando "Criar novo banco de dados" para criar um.',
 
 	// Commands

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -498,7 +498,7 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	formula_err_not_implemented: '函数未实现：$fn()',
 
 	// Plugin
-	plugin_display_name: 'Notion bases',
+	plugin_display_name: 'Notion Bases',
 	no_databases_found: '未找到数据库。使用"创建新数据库"命令来创建一个。',
 
 	// Commands

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ export default class NotionBasesPlugin extends Plugin {
 		)
 
 		// Ribbon — selecionar banco de dados
-		this.addRibbonIcon('table', 'Notion bases', () => {
+		this.addRibbonIcon('table', 'Notion Bases', () => {
 			this.openDatabasePicker()
 		})
 

--- a/styles.css
+++ b/styles.css
@@ -5766,3 +5766,9 @@ body.nb-tl-resizing.nb-tl-resizing.nb-tl-resizing * {
 	white-space: nowrap;
 	vertical-align: baseline;
 }
+
+/* ── Ícones SVG monocromáticos (substituem os antigos emojis) ── */
+.nb-icon {
+	vertical-align: -0.125em;
+	flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary
- New `src/components/icons.tsx`: lucide-style outline icons sized 1em with currentColor so they follow the theme, plus a single shared `COLUMN_TYPE_ICONS` map and `getColumnIcon()` — replacing three duplicated emoji maps (filter-utils, DatabaseTable, ColumnHeader)
- All ~100 emoji across context menus, toolbars, filter pills, cell editors and view tabs replaced with monochrome SVG icons; typographic glyphs (Aa, #, ƒ, Σ) kept
- `ActiveFilter.icon` and `addFilter()` now take a `ReactNode`
- Plugin display name capitalized to "Notion Bases" (proper noun) in all seven locales and the ribbon label; sentence-case lint rules updated with an ignore for the product name
- Hardcoded Portuguese "Nome" in several `addFilter` calls replaced with `t('name_column')`

Closes #66