### PR TITLE
feat: calendar week view supports an end date field for event duration

### DIFF
--- a/src/components/DatabaseCalendar.tsx
+++ b/src/components/DatabaseCalendar.tsx
@@ -188,6 +188,11 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 		[config.schema, activeView.calendarDateField]
 	)
 
+	const endDateField = useMemo(
+		() => config.schema.find(c => c.id === activeView.calendarEndDateField) ?? null,
+		[config.schema, activeView.calendarEndDateField]
+	)
+
 	const visibleCols = useMemo(
 		() => config.schema.filter(col => col.visible && !activeView.hiddenColumns.includes(col.id)),
 		[config.schema, activeView.hiddenColumns]
@@ -362,6 +367,23 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 		const datePart = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
 		await trackSave(app.fileManager.processFrontMatter(file, (fm: Record<string, unknown>) => {
 			const existing = fm[dateField.id]
+			// Shift the end date by the same number of days so the event
+			// keeps its duration when dragged to another day (#58).
+			if (endDateField) {
+				const oldStart = parseDateValue(existing)
+				const oldEnd = parseDateValue(fm[endDateField.id])
+				if (oldStart && oldEnd) {
+					const deltaDays = Math.round((new Date(year, month, day).getTime() - new Date(oldStart.year, oldStart.month, oldStart.day).getTime()) / 86400000)
+					if (deltaDays !== 0) {
+						const newEnd = new Date(oldEnd.year, oldEnd.month, oldEnd.day + deltaDays)
+						const endDatePart = `${newEnd.getFullYear()}-${String(newEnd.getMonth() + 1).padStart(2, '0')}-${String(newEnd.getDate()).padStart(2, '0')}`
+						const existingEnd = fm[endDateField.id]
+						fm[endDateField.id] = (typeof existingEnd === 'string' && existingEnd.includes('T'))
+							? `${endDatePart}T${existingEnd.split('T')[1]}`
+							: endDatePart
+					}
+				}
+			}
 			if (typeof existing === 'string' && existing.includes('T')) {
 				fm[dateField.id] = `${datePart}T${existing.split('T')[1]}`
 			} else {
@@ -414,6 +436,24 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 						key={col.id}
 						className={`nb-menu-item${activeView.calendarDateField === col.id ? ' nb-menu-item--active' : ''}`}
 						onClick={() => { void saveView({ ...activeView, calendarDateField: col.id }); setDateFieldMenuOpen(false) }}
+					>
+						<span className="nb-menu-item-icon"><IconCalendar /></span>
+						<span>{col.name}</span>
+					</button>
+				))}
+				<div className="nb-fields-dropdown-label">{t('end_date_field_label')}</div>
+				<button
+					className={`nb-menu-item${!activeView.calendarEndDateField ? ' nb-menu-item--active' : ''}`}
+					onClick={() => { void saveView({ ...activeView, calendarEndDateField: undefined }); setDateFieldMenuOpen(false) }}
+				>
+					<span className="nb-menu-item-icon">—</span>
+					<span>{t('none_value')}</span>
+				</button>
+				{config.schema.filter(c => c.type === 'date').map(col => (
+					<button
+						key={`end-${col.id}`}
+						className={`nb-menu-item${activeView.calendarEndDateField === col.id ? ' nb-menu-item--active' : ''}`}
+						onClick={() => { void saveView({ ...activeView, calendarEndDateField: col.id }); setDateFieldMenuOpen(false) }}
 					>
 						<span className="nb-menu-item-icon"><IconCalendar /></span>
 						<span>{col.name}</span>
@@ -483,6 +523,24 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 									key={col.id}
 									className={`nb-menu-item${activeView.calendarDateField === col.id ? ' nb-menu-item--active' : ''}`}
 									onClick={() => { void saveView({ ...activeView, calendarDateField: col.id }); setDateFieldMenuOpen(false) }}
+								>
+									<span className="nb-menu-item-icon"><IconCalendar /></span>
+									<span>{col.name}</span>
+								</button>
+							))}
+							<div className="nb-fields-dropdown-label">{t('end_date_field_label')}</div>
+							<button
+								className={`nb-menu-item${!activeView.calendarEndDateField ? ' nb-menu-item--active' : ''}`}
+								onClick={() => { void saveView({ ...activeView, calendarEndDateField: undefined }); setDateFieldMenuOpen(false) }}
+							>
+								<span className="nb-menu-item-icon">—</span>
+								<span>{t('none_value')}</span>
+							</button>
+							{config.schema.filter(c => c.type === 'date').map(col => (
+								<button
+									key={`end-${col.id}`}
+									className={`nb-menu-item${activeView.calendarEndDateField === col.id ? ' nb-menu-item--active' : ''}`}
+									onClick={() => { void saveView({ ...activeView, calendarEndDateField: col.id }); setDateFieldMenuOpen(false) }}
 								>
 									<span className="nb-menu-item-icon"><IconCalendar /></span>
 									<span>{col.name}</span>
@@ -681,18 +739,38 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 											{timedRows.map(row => {
 												const p = parseDateValue((row as Record<string, unknown>)[dateField.id])
 												if (!p || p.hour === undefined || p.minute === undefined) return null
-												const topPct = ((p.hour * 60 + p.minute) / 1440) * 100
+												const startMin = p.hour * 60 + p.minute
+												// Optional end field stretches the card to the real
+												// duration (#58); events crossing midnight are clamped
+												// to the end of the day column.
+												let endMin: number | null = null
+												let endLabel: string | null = null
+												if (endDateField) {
+													const pe = parseDateValue((row as Record<string, unknown>)[endDateField.id])
+													if (pe && pe.hour !== undefined && pe.minute !== undefined) {
+														const dayDelta = new Date(pe.year, pe.month, pe.day).getTime() - new Date(p.year, p.month, p.day).getTime()
+														if (dayDelta > 0) {
+															endMin = 1440
+															endLabel = formatTime(pe.hour, pe.minute)
+														} else if (dayDelta === 0 && pe.hour * 60 + pe.minute > startMin) {
+															endMin = pe.hour * 60 + pe.minute
+															endLabel = formatTime(pe.hour, pe.minute)
+														}
+													}
+												}
+												const topPct = (startMin / 1440) * 100
+												const heightPct = endMin !== null ? ((endMin - startMin) / 1440) * 100 : null
 												return (
 													<div
 														key={row._file.path}
-														className="nb-cal-card nb-cal-card--timed"
+														className={`nb-cal-card nb-cal-card--timed${heightPct !== null ? ' nb-cal-card--spanning' : ''}`}
 														draggable
 														onDragStart={e => handleCardDragStart(e, row)}
 														onClick={e => { e.stopPropagation(); void app.workspace.getLeaf().openFile(row._file) }}
-														style={{ top: `${topPct}%` }}
+														style={{ top: `${topPct}%`, ...(heightPct !== null ? { height: `${heightPct}%` } : {}) }}
 													>
 														<div className="nb-cal-card-title-row">
-															<span className="nb-cal-time-badge">{formatTime(p.hour, p.minute)}</span>
+															<span className="nb-cal-time-badge">{endLabel ? `${formatTime(p.hour, p.minute)}–${endLabel}` : formatTime(p.hour, p.minute)}</span>
 															<span className="nb-cal-card-title">{row._title}</span>
 														</div>
 													</div>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -36,6 +36,7 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	sort_by: 'Sortieren nach',
 	group_by_label: 'Gruppieren nach',
 	date_field_label: 'Datumsfeld',
+	end_date_field_label: 'Enddatumsfeld',
 	cover_field_label: 'Titelbildfeld',
 	card_size_label: 'Kartengröße',
 	row_height_label: 'Zeilenhöhe',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -34,6 +34,7 @@ const en = {
 	sort_by: 'Sort by',
 	group_by_label: 'Group by',
 	date_field_label: 'Date field',
+	end_date_field_label: 'End date field',
 	cover_field_label: 'Cover field',
 	card_size_label: 'Card size',
 	row_height_label: 'Row height',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -36,6 +36,7 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	sort_by: 'Ordenar por',
 	group_by_label: 'Agrupar por',
 	date_field_label: 'Campo de fecha',
+	end_date_field_label: 'Campo de fecha final',
 	cover_field_label: 'Campo de portada',
 	card_size_label: 'Tamaño de tarjeta',
 	row_height_label: 'Altura de fila',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -36,6 +36,7 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	sort_by: 'Trier par',
 	group_by_label: 'Grouper par',
 	date_field_label: 'Champ de date',
+	end_date_field_label: 'Champ de date de fin',
 	cover_field_label: 'Champ de couverture',
 	card_size_label: 'Taille de carte',
 	row_height_label: 'Hauteur de ligne',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -36,6 +36,7 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	sort_by: '並べ替え条件',
 	group_by_label: 'グループ化条件',
 	date_field_label: '日付フィールド',
+	end_date_field_label: '終了日フィールド',
 	cover_field_label: 'カバーフィールド',
 	card_size_label: 'カードサイズ',
 	row_height_label: '行の高さ',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -36,6 +36,7 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	sort_by: 'Ordenar por',
 	group_by_label: 'Agrupar por',
 	date_field_label: 'Campo de data',
+	end_date_field_label: 'Campo de data final',
 	cover_field_label: 'Campo de capa',
 	card_size_label: 'Tamanho dos cards',
 	row_height_label: 'Altura das linhas',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -36,6 +36,7 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	sort_by: '排序条件',
 	group_by_label: '分组条件',
 	date_field_label: '日期字段',
+	end_date_field_label: '结束日期字段',
 	cover_field_label: '封面字段',
 	card_size_label: '卡片大小',
 	row_height_label: '行高',

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,7 @@ export interface ViewConfig {
 	galleryCoverField?: string
 	galleryCardSize?: 'small' | 'medium' | 'large'
 	calendarDateField?: string
+	calendarEndDateField?: string
 	calendarViewMode?: 'month' | 'week'
 	timelineStartField?: string
 	timelineEndField?: string

--- a/styles.css
+++ b/styles.css
@@ -5772,3 +5772,9 @@ body.nb-tl-resizing.nb-tl-resizing.nb-tl-resizing * {
 	vertical-align: -0.125em;
 	flex-shrink: 0;
 }
+
+/* Card do Week view com duração real (campo de data final) */
+.nb-cal-card--spanning {
+	overflow: hidden;
+	align-items: flex-start;
+}


### PR DESCRIPTION
## Summary
- New optional `calendarEndDateField` on the view config, picked in the same date-field menu (desktop dropdown and mobile bottom sheet), mirroring the Timeline's existing start/end field pattern
- Timed cards in the Week view stretch from start to end time instead of the fixed 30-minute block; the badge shows the full time range (e.g. 09:00–10:30)
- Events crossing midnight are clamped to the end of the day column
- Dragging a card to another day shifts the end date by the same number of days, preserving the event duration
- New `end_date_field_label` locale string in all seven languages
- With no end field configured, behavior is unchanged

Closes #58