### PR TITLE
feat: hand-written view filters work, with is_any_of/is_none_of operators

### DIFF
--- a/src/components/DatabaseRoot.tsx
+++ b/src/components/DatabaseRoot.tsx
@@ -4,7 +4,7 @@ import { useApp } from '../context'
 import { DatabaseManager } from '../database-manager'
 import { DatabaseSettingsModal } from '../database-settings-modal'
 import { DatabaseConfig, DEFAULT_DATABASE_CONFIG, DEFAULT_VIEW, EmbedState, ViewConfig } from '../types'
-import { applyFilters } from './filter-utils'
+import { applyFilters, filterConfigsToPills } from './filter-utils'
 import { IconCalendar, IconChart, IconSettings } from './icons'
 import { restoreFilterPills } from '../hooks/useDatabaseRows'
 import { evaluateFormulas } from '../formula-engine'
@@ -431,8 +431,9 @@ export function DatabaseRoot({
 						if (!dbFile) return
 						const restrictToPaths = (() => {
 							const pills = activeView.activePills ?? []
-							if (pills.length === 0) return undefined
-							const filters = restoreFilterPills(pills, config.schema)
+							const seeded = pills.length > 0 ? pills : filterConfigsToPills(activeView.filters)
+							if (seeded.length === 0) return undefined
+							const filters = restoreFilterPills(seeded, config.schema)
 							if (filters.length === 0) return undefined
 							const notes = manager.getNotesInDatabase(dbFile, activeView.includeSubfolders)
 							const rawRows = notes.map(f => manager.getNoteDataSync(f, config.schema))

--- a/src/components/filter-utils.ts
+++ b/src/components/filter-utils.ts
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { ColumnSchema, ConditionalFormatRule, FilterOperator, NoteRow, SortConfig } from '../types'
+import { ColumnSchema, ConditionalFormatRule, FilterConfig, FilterOperator, NoteRow, SortConfig, ViewConfig } from '../types'
 import { t } from '../i18n'
 import { stringifyScalar } from '../value-utils'
 
@@ -64,6 +64,23 @@ export function isMultiValueFilter(f: ActiveFilter): boolean {
 
 export function parseMultiValue(value: string): string[] {
 	return value.split(MULTI_VALUE_SEPARATOR).filter(v => v !== '')
+}
+
+/**
+ * Hand-written `filters:` from the view frontmatter, normalized into the
+ * activePills shape so they run through the same filter engine (#64).
+ * `is_any_of`/`is_none_of` become multi-value `is`/`is_not`, and an array
+ * value is joined with the multi-value separator.
+ */
+export function filterConfigsToPills(filters: FilterConfig[] | undefined): NonNullable<ViewConfig['activePills']> {
+	if (!filters || filters.length === 0) return []
+	return filters.filter(f => f && typeof f.columnId === 'string').map(f => ({
+		id: f.id ?? crypto.randomUUID(),
+		columnId: f.columnId,
+		operator: f.operator === 'is_any_of' ? 'is' as const : f.operator === 'is_none_of' ? 'is_not' as const : f.operator,
+		value: Array.isArray(f.value) ? f.value.map(String).join(MULTI_VALUE_SEPARATOR) : String(f.value ?? ''),
+		conjunction: f.conjunction === 'or' ? 'or' as const : 'and' as const,
+	}))
 }
 
 export function toggleMultiValue(current: string, option: string): string {

--- a/src/hooks/useDatabaseRows.ts
+++ b/src/hooks/useDatabaseRows.ts
@@ -5,7 +5,7 @@ import {
 	ColumnSchema, DatabaseConfig, DEFAULT_DATABASE_CONFIG, NoteRow, ViewConfig,
 } from '../types'
 import { evaluateFormulas } from '../formula-engine'
-import { ActiveFilter } from '../components/filter-utils'
+import { ActiveFilter, filterConfigsToPills } from '../components/filter-utils'
 import { getColumnIcon } from '../components/icons'
 import { t } from '../i18n'
 
@@ -140,7 +140,9 @@ export function useDatabaseRows(options: UseDatabaseRowsOptions): UseDatabaseRow
 		if (!filtersInitialized.current) {
 			filtersInitialized.current = true
 			const pills = externalViewRef.current.activePills ?? []
-			setActiveFilters(restoreFilterPills(pills, cfg.schema))
+			// Hand-written `filters:` seed the pills when the view has none (#64)
+			const seeded = pills.length > 0 ? pills : filterConfigsToPills(externalViewRef.current.filters)
+			setActiveFilters(restoreFilterPills(seeded, cfg.schema))
 		}
 
 		setConfig({ schema: cfg.schema, views: cfg.views })

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,11 +82,16 @@ export type FilterOperator =
 	| 'is_empty'
 	| 'is_not_empty'
 
+// Hand-written view filters (`filters:` in `_database.md` frontmatter).
+// Normalized into filter pills on load: `is_any_of`/`is_none_of` and array
+// values map onto the multi-value `is`/`is_not` machinery, and `conjunction`
+// starts a new OR group. Ignored when the view already has activePills.
 export interface FilterConfig {
-	id: string
+	id?: string
 	columnId: string
-	operator: FilterOperator
-	value: string
+	operator: FilterOperator | 'is_any_of' | 'is_none_of'
+	value?: string | string[]
+	conjunction?: 'and' | 'or'
 }
 
 export interface SortConfig {

--- a/tests/filter-utils.test.ts
+++ b/tests/filter-utils.test.ts
@@ -7,6 +7,7 @@ import {
 	getDefaultOperator,
 	parseMultiValue,
 	toggleMultiValue,
+	filterConfigsToPills,
 	isMultiValueFilter,
 	ActiveFilter,
 	MULTI_VALUE_SEPARATOR,
@@ -345,5 +346,67 @@ describe('applySorts', () => {
 		const original = [...rows]
 		applySorts(rows, [{ columnId: '_title', direction: 'asc' }])
 		expect(rows).toEqual(original)
+	})
+})
+
+// ── filterConfigsToPills (#64) ───────────────────────────────────────────────
+
+describe('filterConfigsToPills', () => {
+	it('returns empty for undefined or empty input', () => {
+		expect(filterConfigsToPills(undefined)).toEqual([])
+		expect(filterConfigsToPills([])).toEqual([])
+	})
+
+	it('normalizes is_any_of to a multi-value is pill', () => {
+		const [pill] = filterConfigsToPills([
+			{ columnId: 'type', operator: 'is_any_of', value: ['Journal', 'Daily'] },
+		])
+		expect(pill.operator).toBe('is')
+		expect(pill.value).toBe(`Journal${MULTI_VALUE_SEPARATOR}Daily`)
+		expect(pill.conjunction).toBe('and')
+	})
+
+	it('normalizes is_none_of to a multi-value is_not pill', () => {
+		const [pill] = filterConfigsToPills([
+			{ columnId: 'type', operator: 'is_none_of', value: ['Archive'] },
+		])
+		expect(pill.operator).toBe('is_not')
+		expect(pill.value).toBe('Archive')
+	})
+
+	it('keeps plain operators, string values and or conjunction', () => {
+		const [a, b] = filterConfigsToPills([
+			{ columnId: 'archived', operator: 'is_unchecked' },
+			{ columnId: 'status', operator: 'is', value: 'Done', conjunction: 'or' },
+		])
+		expect(a.operator).toBe('is_unchecked')
+		expect(a.value).toBe('')
+		expect(b.conjunction).toBe('or')
+	})
+
+	it('drops malformed entries without a columnId', () => {
+		const pills = filterConfigsToPills([
+			{ operator: 'is', value: 'x' } as never,
+			{ columnId: 'ok', operator: 'is', value: 'y' },
+		])
+		expect(pills).toHaveLength(1)
+		expect(pills[0].columnId).toBe('ok')
+	})
+
+	it('produces pills that filter rows end-to-end (is any of)', () => {
+		const rows = [
+			makeRow({ _title: 'a', type: 'Journal', archived: false }),
+			makeRow({ _title: 'b', type: 'Daily', archived: false }),
+			makeRow({ _title: 'c', type: 'Meeting', archived: false }),
+		]
+		const pills = filterConfigsToPills([
+			{ columnId: 'type', operator: 'is_any_of', value: ['Journal', 'Daily'] },
+		])
+		const active: ActiveFilter[] = pills.map(p => ({
+			id: p.id, columnId: p.columnId, columnName: p.columnId, columnType: 'select',
+			icon: '', operator: p.operator, value: p.value, conjunction: p.conjunction ?? 'and',
+		}))
+		const result = applyFilters(rows, active)
+		expect(result.map(r => r._title)).toEqual(['a', 'b'])
 	})
 })


### PR DESCRIPTION
## Summary
The `filters:` list in a view's frontmatter was declared but never applied at runtime — hand-written filters were silently ignored, which read as "filters are AND-only" to anyone porting a database from Notion. The interactive pills already supported multi-value select filters and OR conjunctions; this wires the YAML path into the same engine.

- `filterConfigsToPills()` normalizes `FilterConfig` entries into the activePills shape: `is_any_of`/`is_none_of` map to the multi-value `is`/`is_not` machinery, array values are joined with the multi-value separator, and `conjunction: or` starts a new OR group (cross-column OR included)
- Views seed their pills from `filters:` when they have no `activePills` (both on load and in the settings modal's restricted-path computation)
- `FilterConfig`: `id` now optional, `value` accepts string or string[], operator accepts the two aliases, `conjunction` added
- Six new unit tests covering normalization and end-to-end filtering

Example that now works as written:
```yaml
filters:
  - columnId: Archived
    operator: is_unchecked
  - columnId: Type
    operator: is_any_of
    value: [Journal, Daily]
```

Closes #64