### PR TITLE
feat: accept Notion formula names and add the formula reference doc

### DIFF
--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -1,0 +1,116 @@
+# Formula reference
+
+Formula columns compute a value per row from the other columns of the note. The syntax is spreadsheet-style — if you have used Excel or Google Sheets, you already know most of it.
+
+```text
+IF(status = "Done", "✓", DATEDIFF(created, NOW(), "days") & " days open")
+```
+
+## Referencing columns
+
+| Syntax | Example | Notes |
+|--------|---------|-------|
+| Bare name | `price * quantity` | Works when the name has no spaces |
+| Brackets | `[Due Date]` | For names with spaces or symbols |
+| `PROP("name")` | `PROP("Due Date")` | Notion-style; the name is a string, matched case-insensitively |
+| `_title` | `LEN(_title)` | The note's title |
+
+## Operators
+
+| Operator | Meaning |
+|----------|---------|
+| `+` `-` `*` `/` | Arithmetic (division by zero returns empty, not an error) |
+| `&` | Text concatenation: `"v" & version` |
+| `=` or `==` | Equal |
+| `<>` or `!=` | Not equal |
+| `>` `<` `>=` `<=` | Comparison (numbers, text or dates) |
+
+Function names are case-insensitive: `if(...)`, `If(...)` and `IF(...)` are the same function.
+
+## Logic
+
+| Function | Description |
+|----------|-------------|
+| `IF(condition, then, else?)` | Returns `then` when the condition is truthy, otherwise `else` (or empty) |
+| `IFS(cond1, val1, cond2, val2, …)` | Returns the value paired with the first true condition |
+| `AND(a, b, …)` | True when every argument is truthy |
+| `OR(a, b, …)` | True when any argument is truthy |
+| `NOT(value)` | Logical negation |
+
+## Aggregation
+
+With a single column argument, these operate **across all rows** of the database. `SUM`, `MIN` and `MAX` also accept a list of values; `AVG`, `COUNT` and `COUNTA` take a column only.
+
+| Function | Description |
+|----------|-------------|
+| `SUM(column)` / `SUM(a, b, …)` | Sum |
+| `AVG(column)` (aliases: `AVERAGE`, `MEAN`) | Arithmetic mean |
+| `COUNT(column)` | Count of numeric values |
+| `COUNTA(column)` | Count of non-empty values |
+| `MIN(…)` / `MAX(…)` | Smallest / largest value |
+
+## Text
+
+| Function | Description |
+|----------|-------------|
+| `CONCAT(a, b, …)` | Joins values into one string |
+| `LEN(text)` (alias: `LENGTH`) | Number of characters |
+| `UPPER(text)` / `LOWER(text)` | Case conversion |
+| `TRIM(text)` | Strips surrounding whitespace |
+| `LEFT(text, n)` / `RIGHT(text, n)` | First / last `n` characters |
+| `MID(text, start, count)` | `count` characters starting at position `start` (1-based) |
+| `SUBSTITUTE(text, from, to)` | Replaces every occurrence of `from` with `to` (literal, no regex) |
+
+## Math
+
+| Function | Description |
+|----------|-------------|
+| `ROUND(n, decimals?)` | Rounds to `decimals` places (default 0) |
+| `FLOOR(n)` / `CEIL(n)` (alias: `CEILING`) | Round down / up to an integer |
+| `ABS(n)` | Absolute value |
+| `MOD(n, divisor)` | Remainder |
+| `POWER(base, exponent)` (alias: `POW`) | Exponentiation |
+| `SQRT(n)` | Square root |
+
+## Empty values and conversion
+
+| Function | Description |
+|----------|-------------|
+| `ISNULL(value)` | True when the value is missing |
+| `ISEMPTY(value)` (alias: `EMPTY`) | True when missing or blank |
+| `COALESCE(a, b, …)` | First non-empty argument |
+| `TEXT(value)` | Converts to text |
+| `VALUE(text)` (alias: `TONUMBER`) | Converts to a number |
+
+## Dates
+
+Date units accept singular, plural and short forms: `years`/`y`, `months`/`m`, `weeks`/`w`, `days`/`d` (the default), `hours`/`h`, `minutes`/`min`.
+
+| Function | Description |
+|----------|-------------|
+| `NOW()` | Current date and time |
+| `TODAY()` | Current date at midnight |
+| `DATE(year, month, day)` | Builds a date |
+| `YEAR(date)` `MONTH(date)` `DAY(date)` `HOUR(date)` `MINUTE(date)` | Extracts a component (`DAY` is the day of the month) |
+| `WEEKDAY(date)` | Day of the week: 1 = Sunday … 7 = Saturday |
+| `DATEDIFF(start, end, unit?)` (alias: `DATEDIF`) | `end − start` in the given unit |
+| `DATEBETWEEN(end, start, unit?)` | Notion's argument order: `end − start` |
+| `DATEADD(date, n, unit?)` | Date shifted forward by `n` units |
+| `DATESUBTRACT(date, n, unit?)` | Date shifted back by `n` units |
+| `FORMATDATE(date, format)` | Formats with `YYYY` `YY` `MM` `DD` `HH` `mm` `ss` tokens, e.g. `"DD/MM/YYYY"` |
+
+Day differences are computed on calendar days, so daylight-saving transitions do not shift the result.
+
+## Coming from Notion?
+
+Most Notion formula names work as-is — `dateBetween`, `dateSubtract`, `dateAdd`, `prop`, `formatDate`, `length`, `empty`, `toNumber`, `mean`, `pow`, `if`, `and`, `or`, `not`, `concat`, `abs`, `ceil`, `floor`, `round`, `sqrt`, `min`, `max`, `now`, `today` all evaluate the way you expect. The differences worth knowing:
+
+| Notion | Here | Note |
+|--------|------|------|
+| `prop("Status")` | `PROP("Status")`, `[Status]` or `status` | All three work |
+| `day(date)` | `WEEKDAY(date)` | Notion's `day()` is the day of the **week**; here it returns 1–7 (Sunday = 1) instead of 0–6 |
+| `date(date)` | `DAY(date)` | Day of the month; `DATE(y, m, d)` here is the date constructor |
+| `format(x)` | `TEXT(x)` | |
+| `replaceAll(t, a, b)` | `SUBSTITUTE(t, a, b)` | Literal match — no regular expressions |
+| `slice(t, a, b)` | `MID(t, start, count)` | 1-based start and a length, not an end index |
+| Ternary `a ? b : c` | `IF(a, b, c)` | |

--- a/src/formula-engine.ts
+++ b/src/formula-engine.ts
@@ -177,7 +177,8 @@ class Parser {
 					while (this.is('COMMA')) { this.eat(); args.push(this.expr()) }
 				}
 				this.expect('RPAREN')
-				return { k: 'call', fn: t.val.toUpperCase(), args }
+				const up = t.val.toUpperCase()
+				return { k: 'call', fn: FN_ALIASES[up] ?? up, args }
 			}
 			return { k: 'col', name: t.val }
 		}
@@ -344,7 +345,20 @@ const KNOWN_FNS = new Set([
 	'TEXT', 'VALUE',
 	'NOW', 'TODAY', 'DATE', 'YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE',
 	'WEEKDAY', 'DATEDIF', 'DATEDIFF', 'DATEADD', 'FORMATDATE',
+	'DATEBETWEEN', 'DATESUBTRACT', 'PROP',
 ])
+
+// Notion formula names accepted as spellings of the native functions (#72).
+// Only names whose semantics and argument order match exactly are aliased;
+// dateBetween and dateSubtract differ and get their own handlers instead.
+const FN_ALIASES: Record<string, string> = {
+	LENGTH: 'LEN',
+	TONUMBER: 'VALUE',
+	EMPTY: 'ISEMPTY',
+	MEAN: 'AVG',
+	POW: 'POWER',
+	CEILING: 'CEIL',
+}
 
 // ── Avaliador ─────────────────────────────────────────────────────────────────
 
@@ -625,6 +639,26 @@ function evalNode(n: Node, ctx: Ctx): unknown {
 				const d = toDate(evalNode(args[0], ctx))
 				if (!d) return null
 				return formatDatePattern(d, toStr(evalNode(args[1], ctx)))
+			}
+			// Notion's dateBetween(later, earlier, unit) — same math as DATEDIF
+			// but with the arguments in the opposite order (#72).
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_DATEBETWEEN: if (fn === 'DATEBETWEEN') {
+				if (args.length < 2 || args.length > 3) throw new FormulaError('DATEBETWEEN(fim, inicio, unidade?)')
+				return evalNode({ k: 'call', fn: 'DATEDIF', args: [args[1], args[0], ...(args[2] ? [args[2]] : [])] }, ctx)
+			}
+			// Notion's dateSubtract(date, n, unit) = DATEADD with a negated amount (#72).
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_DATESUBTRACT: if (fn === 'DATESUBTRACT') {
+				if (args.length < 2 || args.length > 3) throw new FormulaError('DATESUBTRACT(data, n, unidade?)')
+				const negated: Node = { k: 'neg', x: args[1] }
+				return evalNode({ k: 'call', fn: 'DATEADD', args: [args[0], negated, ...(args[2] ? [args[2]] : [])] }, ctx)
+			}
+			// Notion's prop("Column name") — resolves a column by its name (#72).
+			// eslint-disable-next-line no-unused-labels -- labels used as named case markers for function dispatch readability
+			case_PROP: if (fn === 'PROP') {
+				if (args.length !== 1) throw new FormulaError('PROP(nome)')
+				return resolveCol(toStr(evalNode(args[0], ctx)), ctx)
 			}
 
 			throw new FormulaError(i18n('formula_err_not_implemented').replace('$fn', fn))

--- a/tests/formula-engine.test.ts
+++ b/tests/formula-engine.test.ts
@@ -381,3 +381,39 @@ describe('error handling', () => {
 		expect(evalF('  ')).toBeNull()
 	})
 })
+
+// ── Notion-style names (#72) ─────────────────────────────────────────────────
+
+describe('Notion formula names', () => {
+	it('dateBetween uses Notion argument order (later, earlier)', () => {
+		expect(evalF('dateBetween(DATE(2026, 1, 10), DATE(2026, 1, 1), "days")')).toBe(9)
+		expect(evalF('DATEDIFF(DATE(2026, 1, 1), DATE(2026, 1, 10), "days")')).toBe(9)
+	})
+
+	it('dateSubtract shifts a date backwards', () => {
+		expect(evalF('FORMATDATE(dateSubtract(DATE(2026, 3, 15), 1, "months"), "YYYY-MM-DD")')).toBe('2026-02-15')
+	})
+
+	it('dateAdd works under its Notion spelling', () => {
+		expect(evalF('FORMATDATE(dateAdd(DATE(2026, 1, 1), 2, "weeks"), "YYYY-MM-DD")')).toBe('2026-01-15')
+	})
+
+	it('prop resolves a column by display name, case-insensitively', () => {
+		expect(evalF('prop("Price") * 2', { price: 10 })).toBe(20)
+		expect(evalF('prop("quantity") + 1', { qty: 4 })).toBe(5)
+	})
+
+	it('aliases map to the native functions', () => {
+		expect(evalF('length("hello")')).toBe(5)
+		expect(evalF('toNumber("42") + 1')).toBe(43)
+		expect(evalF('empty("")')).toBe(true)
+		expect(evalF('mean(price)', { price: 4 })).toBe(4)
+		expect(evalF('pow(2, 10)')).toBe(1024)
+		expect(evalF('ceiling(1.2)')).toBe(2)
+	})
+
+	it('aliases pass syntax validation', () => {
+		expect(validateFormulaSyntax('dateBetween(NOW(), TODAY(), "hours")')).toBeNull()
+		expect(validateFormulaSyntax('prop("Status")')).toBeNull()
+	})
+})


### PR DESCRIPTION
## Summary
The README linked to `docs/formulas.md`, which did not exist — users clicking through for the function list landed on a 404, and Notion spellings like `dateBetween()` failed with an unknown-function error.

- `FN_ALIASES` maps Notion names whose semantics match exactly onto the native functions: `length`, `toNumber`, `empty`, `mean`, `pow`, `ceiling`
- `DATEBETWEEN(end, start, unit?)` implemented with Notion's reversed argument order on top of `DATEDIF` (a blind alias would have flipped the sign of every result); `DATESUBTRACT(date, n, unit?)` as a negated `DATEADD`; `PROP("name")` resolves a column by display name
- `docs/formulas.md`: full reference — operators, every function with signature and grouping, date units, format tokens — plus a coming-from-Notion mapping table with the semantic traps called out (`day()` vs `WEEKDAY`, `date()` vs `DAY`, `slice` vs `MID`)
- Seven new unit tests (203 total)

Closes #72