### PR TITLE
feat: per-view card title field and graceful duplicate renames

### DIFF
--- a/src/components/DatabaseBoard.tsx
+++ b/src/components/DatabaseBoard.tsx
@@ -9,6 +9,7 @@ import {
 	ActiveFilter, applyFilters, applySorts,
 	getDefaultOperator,
 	getCardConditionalStyle,
+	getCardTitle,
 } from './filter-utils'
 import { getColumnIcon, IconFile, IconCopy, IconTrash } from './icons'
 import { FilterPillsRow } from './FilterPillsRow'
@@ -81,11 +82,12 @@ interface BoardCardProps {
 	onTouchStart?: (e: React.TouchEvent, file: TFile) => void
 	onContextMenu?: (e: React.MouseEvent, file: TFile) => void
 	cardStyle?: React.CSSProperties
+	cardTitleField?: string
 }
 
 const BoardCard = React.memo(function BoardCard({
 	row, isMobile, visibleCols, dbFolderPath, includeSubfolders,
-	onOpen, onDragStart, onTouchStart, onContextMenu, cardStyle,
+	onOpen, onDragStart, onTouchStart, onContextMenu, cardStyle, cardTitleField,
 }: BoardCardProps) {
 	const fileFolder = row._file.parent?.path ?? ''
 	const relPath = includeSubfolders && fileFolder.length > dbFolderPath.length
@@ -104,7 +106,7 @@ const BoardCard = React.memo(function BoardCard({
 			onContextMenu={!isMobile ? e => { e.preventDefault(); onContextMenu?.(e, row._file) } : undefined}
 			onClick={() => onOpen(row._file)}
 		>
-			<div className="nb-board-card-title">{row._title}</div>
+			<div className="nb-board-card-title">{getCardTitle(row, cardTitleField)}</div>
 			{relPath ? <div className="nb-folder-path">{relPath}</div> : null}
 			{visibleCols.length > 0 && (
 				<div className="nb-board-card-props">
@@ -594,6 +596,24 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 						<span>{col.name}</span>
 					</button>
 				))}
+							<div className="nb-fields-dropdown-label">{t('card_title_field_label')}</div>
+				<button
+					className={`nb-menu-item${!activeView.cardTitleField ? ' nb-menu-item--active' : ''}`}
+					onClick={() => { void saveView({ ...activeView, cardTitleField: undefined }); setGroupByMenuOpen(false) }}
+				>
+					<span className="nb-menu-item-icon"><IconFile /></span>
+					<span>{t('name_column')}</span>
+				</button>
+				{config.schema.filter(c => c.type !== 'title').map(col => (
+					<button
+						key={`ct-${col.id}`}
+						className={`nb-menu-item${activeView.cardTitleField === col.id ? ' nb-menu-item--active' : ''}`}
+						onClick={() => { void saveView({ ...activeView, cardTitleField: col.id }); setGroupByMenuOpen(false) }}
+					>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
+						<span>{col.name}</span>
+					</button>
+				))}
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
 				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
@@ -653,6 +673,24 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 									key={col.id}
 									className={`nb-menu-item${activeView.groupByColumnId === col.id ? ' nb-menu-item--active' : ''}`}
 									onClick={() => { void saveView({ ...activeView, groupByColumnId: col.id }); setGroupByMenuOpen(false) }}
+								>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
+									<span>{col.name}</span>
+								</button>
+							))}
+													<div className="nb-fields-dropdown-label">{t('card_title_field_label')}</div>
+							<button
+								className={`nb-menu-item${!activeView.cardTitleField ? ' nb-menu-item--active' : ''}`}
+								onClick={() => { void saveView({ ...activeView, cardTitleField: undefined }); setGroupByMenuOpen(false) }}
+							>
+								<span className="nb-menu-item-icon"><IconFile /></span>
+								<span>{t('name_column')}</span>
+							</button>
+							{config.schema.filter(c => c.type !== 'title').map(col => (
+								<button
+									key={`ct-${col.id}`}
+									className={`nb-menu-item${activeView.cardTitleField === col.id ? ' nb-menu-item--active' : ''}`}
+									onClick={() => { void saveView({ ...activeView, cardTitleField: col.id }); setGroupByMenuOpen(false) }}
 								>
 									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 									<span>{col.name}</span>
@@ -881,6 +919,7 @@ export function DatabaseBoard({ dbFile, manager, externalView, onViewChange }: D
 												<BoardCard
 													key={row._file.path}
 													row={row}
+													cardTitleField={activeView.cardTitleField}
 													isMobile={isMobile}
 													visibleCols={visibleCols}
 													dbFolderPath={dbFolderPath}

--- a/src/components/DatabaseCalendar.tsx
+++ b/src/components/DatabaseCalendar.tsx
@@ -8,6 +8,7 @@ import {
 import {
 	ActiveFilter, applyFilters,
 	getDefaultOperator,
+	getCardTitle,
 } from './filter-utils'
 import { getColumnIcon, IconFile, IconCalendar, IconPlus, IconCopy, IconTrash } from './icons'
 import { FilterPillsRow } from './FilterPillsRow'
@@ -459,6 +460,24 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 						<span>{col.name}</span>
 					</button>
 				))}
+				<div className="nb-fields-dropdown-label">{t('card_title_field_label')}</div>
+				<button
+					className={`nb-menu-item${!activeView.cardTitleField ? ' nb-menu-item--active' : ''}`}
+					onClick={() => { void saveView({ ...activeView, cardTitleField: undefined }); setDateFieldMenuOpen(false) }}
+				>
+					<span className="nb-menu-item-icon"><IconFile /></span>
+					<span>{t('name_column')}</span>
+				</button>
+				{config.schema.filter(c => c.type !== 'title').map(col => (
+					<button
+						key={`ct-${col.id}`}
+						className={`nb-menu-item${activeView.cardTitleField === col.id ? ' nb-menu-item--active' : ''}`}
+						onClick={() => { void saveView({ ...activeView, cardTitleField: col.id }); setDateFieldMenuOpen(false) }}
+					>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
+						<span>{col.name}</span>
+					</button>
+				))}
 			</BottomSheet>
 			<BottomSheet open={fieldsMenuOpen} onClose={() => setFieldsMenuOpen(false)} title={t('fields')}>
 				{config.schema.map(col => (
@@ -543,6 +562,24 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 									onClick={() => { void saveView({ ...activeView, calendarEndDateField: col.id }); setDateFieldMenuOpen(false) }}
 								>
 									<span className="nb-menu-item-icon"><IconCalendar /></span>
+									<span>{col.name}</span>
+								</button>
+							))}
+							<div className="nb-fields-dropdown-label">{t('card_title_field_label')}</div>
+							<button
+								className={`nb-menu-item${!activeView.cardTitleField ? ' nb-menu-item--active' : ''}`}
+								onClick={() => { void saveView({ ...activeView, cardTitleField: undefined }); setDateFieldMenuOpen(false) }}
+							>
+								<span className="nb-menu-item-icon"><IconFile /></span>
+								<span>{t('name_column')}</span>
+							</button>
+							{config.schema.filter(c => c.type !== 'title').map(col => (
+								<button
+									key={`ct-${col.id}`}
+									className={`nb-menu-item${activeView.cardTitleField === col.id ? ' nb-menu-item--active' : ''}`}
+									onClick={() => { void saveView({ ...activeView, cardTitleField: col.id }); setDateFieldMenuOpen(false) }}
+								>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
 									<span>{col.name}</span>
 								</button>
 							))}
@@ -680,7 +717,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 													onDragStart={e => handleCardDragStart(e, row)}
 													onClick={e => { e.stopPropagation(); void app.workspace.getLeaf().openFile(row._file) }}
 												>
-													<span className="nb-cal-card-title">{row._title}</span>
+													<span className="nb-cal-card-title">{getCardTitle(row, activeView.cardTitleField)}</span>
 												</div>
 											))}
 										</div>
@@ -771,7 +808,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 													>
 														<div className="nb-cal-card-title-row">
 															<span className="nb-cal-time-badge">{endLabel ? `${formatTime(p.hour, p.minute)}–${endLabel}` : formatTime(p.hour, p.minute)}</span>
-															<span className="nb-cal-card-title">{row._title}</span>
+															<span className="nb-cal-card-title">{getCardTitle(row, activeView.cardTitleField)}</span>
 														</div>
 													</div>
 												)
@@ -829,7 +866,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 													>
 														<div className="nb-cal-card-title-row">
 															{dateField && (() => { const tm = getRowTime(row, dateField.id); return tm ? <span className="nb-cal-time-badge">{tm}</span> : null })()}
-															<span className="nb-cal-card-title">{row._title}</span>
+															<span className="nb-cal-card-title">{getCardTitle(row, activeView.cardTitleField)}</span>
 														</div>
 														{!isMobile && (() => {
 															const dbFolder = dbFile?.parent?.path ?? ''
@@ -882,7 +919,7 @@ export function DatabaseCalendar({ dbFile, manager, externalView, onViewChange }
 										onDragStart={e => handleCardDragStart(e, row)}
 										onClick={() => { void app.workspace.getLeaf().openFile(row._file) }}
 									>
-										<span className="nb-cal-card-title">{row._title}</span>
+										<span className="nb-cal-card-title">{getCardTitle(row, activeView.cardTitleField)}</span>
 										{(() => {
 											const dbFolder = dbFile?.parent?.path ?? ''
 											const fileFolder = row._file.parent?.path ?? ''

--- a/src/components/DatabaseTimeline.tsx
+++ b/src/components/DatabaseTimeline.tsx
@@ -8,6 +8,7 @@ import {
 import {
 	ActiveFilter, applyFilters, applySorts,
 	getDefaultOperator,
+	getCardTitle,
 } from './filter-utils'
 import { getColumnIcon, IconFile, IconCalendar, IconCopy, IconTrash } from './icons'
 import { FilterPillsRow } from './FilterPillsRow'
@@ -149,12 +150,13 @@ interface TimelineBarProps {
 	onOpen: (file: TFile) => void
 	onContextMenu: (file: TFile) => void
 	onResizeStart: (filePath: string, handle: 'left' | 'right', startX: number, origBarLeft: number, origBarWidth: number, startFieldId: string | null, endFieldId: string | null) => void
+	cardTitleField?: string
 }
 
 const TimelineBar = React.memo(function TimelineBar({
 	row, barLeft, barWidth, isMobile, visibleCols, dbFolderPath, includeSubfolders,
 	origBarLeft, origBarWidth, startFieldId, endFieldId,
-	onOpen, onContextMenu, onResizeStart,
+	onOpen, onContextMenu, onResizeStart, cardTitleField,
 }: TimelineBarProps) {
 	const fileFolder = row._file.parent?.path ?? ''
 	const relPath = includeSubfolders && fileFolder.length > dbFolderPath.length
@@ -171,7 +173,7 @@ const TimelineBar = React.memo(function TimelineBar({
 					e.stopPropagation(); e.preventDefault()
 					onResizeStart(row._file.path, 'left', e.clientX, origBarLeft, origBarWidth, startFieldId, endFieldId)
 				}} />
-			<span className="nb-tl-bar-title">{row._title}</span>
+			<span className="nb-tl-bar-title">{getCardTitle(row, cardTitleField)}</span>
 			{relPath ? <span className="nb-folder-path" style={{ marginLeft: 4 }}>{relPath}</span> : null}
 			{visibleCols.map(col => {
 				const val = row[col.id]
@@ -516,6 +518,24 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 						<span className="nb-field-name">{col.name}</span>
 					</label>
 				))}
+							<div className="nb-fields-dropdown-label">{t('card_title_field_label')}</div>
+				<button
+					className={`nb-menu-item${!activeView.cardTitleField ? ' nb-menu-item--active' : ''}`}
+					onClick={() => { void saveView({ ...activeView, cardTitleField: undefined }); setFieldsMenuOpen(false) }}
+				>
+					<span className="nb-menu-item-icon"><IconFile /></span>
+					<span>{t('name_column')}</span>
+				</button>
+				{config.schema.filter(c => c.type !== 'title').map(col => (
+					<button
+						key={`ct-${col.id}`}
+						className={`nb-menu-item${activeView.cardTitleField === col.id ? ' nb-menu-item--active' : ''}`}
+						onClick={() => { void saveView({ ...activeView, cardTitleField: col.id }); setFieldsMenuOpen(false) }}
+					>
+						<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
+						<span>{col.name}</span>
+					</button>
+				))}
 			</BottomSheet>
 			<BottomSheet open={filterMenuOpen} onClose={() => setFilterMenuOpen(false)} title={t('filter')}>
 				<button className="nb-menu-item" onClick={() => addFilter('_title', t('name_column'), <IconFile />, 'title')}>
@@ -585,6 +605,24 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 									<span className="nb-field-icon">{getColumnIcon(col.type)}</span>
 									<span className="nb-field-name">{col.name}</span>
 								</label>
+							))}
+													<div className="nb-fields-dropdown-label">{t('card_title_field_label')}</div>
+							<button
+								className={`nb-menu-item${!activeView.cardTitleField ? ' nb-menu-item--active' : ''}`}
+								onClick={() => { void saveView({ ...activeView, cardTitleField: undefined }); setFieldsMenuOpen(false) }}
+							>
+								<span className="nb-menu-item-icon"><IconFile /></span>
+								<span>{t('name_column')}</span>
+							</button>
+							{config.schema.filter(c => c.type !== 'title').map(col => (
+								<button
+									key={`ct-${col.id}`}
+									className={`nb-menu-item${activeView.cardTitleField === col.id ? ' nb-menu-item--active' : ''}`}
+									onClick={() => { void saveView({ ...activeView, cardTitleField: col.id }); setFieldsMenuOpen(false) }}
+								>
+									<span className="nb-menu-item-icon">{getColumnIcon(col.type)}</span>
+									<span>{col.name}</span>
+								</button>
 							))}
 						</div>
 					)}
@@ -682,7 +720,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 							) : (
 								<div key={item.row._file.path} className="nb-tl-sidebar-row" style={{ height: ROW_H }}
 									onClick={() => { void app.workspace.getLeaf().openFile(item.row._file) }}>
-									<span className="nb-tl-row-label">{item.row._title}</span>
+									<span className="nb-tl-row-label">{getCardTitle(item.row, activeView.cardTitleField)}</span>
 									{(() => {
 										const dbFolder = dbFile?.parent?.path ?? ''
 										const fileFolder = item.row._file.parent?.path ?? ''
@@ -733,6 +771,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 											return (
 												<TimelineBar
 													row={item.row}
+													cardTitleField={activeView.cardTitleField}
 													barLeft={bLeft}
 													barWidth={bWidth}
 													origBarLeft={item.barLeft}
@@ -768,7 +807,7 @@ export function DatabaseTimeline({ dbFile, manager, externalView, onViewChange }
 							{noIntervalRows.map(row => (
 								<div key={row._file.path} className="nb-cal-card nb-cal-card--no-date"
 									onClick={() => { void app.workspace.getLeaf().openFile(row._file) }}>
-									<span className="nb-cal-card-title">{row._title}</span>
+									<span className="nb-cal-card-title">{getCardTitle(row, activeView.cardTitleField)}</span>
 								</div>
 							))}
 						</div>

--- a/src/components/filter-utils.ts
+++ b/src/components/filter-utils.ts
@@ -237,6 +237,20 @@ export function applyFilters(rows: NoteRow[], filters: ActiveFilter[]): NoteRow[
 }
 
 /**
+ * Title shown on a card (#41): the view's cardTitleField value when set and
+ * non-empty, else the filename. Recurring events can share a display name
+ * while each row keeps a unique file underneath.
+ */
+export function getCardTitle(row: NoteRow, cardTitleField: string | undefined): string {
+	if (cardTitleField) {
+		const v = row[cardTitleField]
+		const s = v === null || v === undefined ? '' : stringifyScalar(v).trim()
+		if (s) return s
+	}
+	return row._title
+}
+
+/**
  * Counts the rows matching a summary statistic's condition (#67). Runs over
  * the full row set (not the filtered view) so the number is a snapshot of the
  * whole database.

--- a/src/database-manager.ts
+++ b/src/database-manager.ts
@@ -1,4 +1,4 @@
-import { App, TFile, TFolder, normalizePath, parseYaml } from 'obsidian'
+import { App, Notice, TFile, TFolder, normalizePath, parseYaml } from 'obsidian'
 import { t } from './i18n'
 import {
 	ColumnSchema,
@@ -324,10 +324,21 @@ export class DatabaseManager {
 	}
 
 	async renameNote(file: TFile, newBasename: string): Promise<void> {
-		if (!newBasename.trim() || newBasename === file.basename) return
-		const newPath = normalizePath(
-			`${file.parent?.path ?? ''}/${newBasename.trim()}.md`
-		)
+		const trimmed = newBasename.trim()
+		if (!trimmed || trimmed === file.basename) return
+		const folder = file.parent?.path ?? ''
+		// A row's title is its filename, so a duplicate title would collide on
+		// disk. Auto-suffix to the first free name and tell the user (#41).
+		let finalName = trimmed
+		let newPath = normalizePath(`${folder}/${finalName}.md`)
+		let i = 2
+		while (this.app.vault.getAbstractFileByPath(newPath) && newPath !== file.path) {
+			finalName = `${trimmed} ${i++}`
+			newPath = normalizePath(`${folder}/${finalName}.md`)
+		}
+		if (finalName !== trimmed) {
+			new Notice(t('renamed_with_suffix').replace('$name', trimmed).replace('$final', finalName), 5000)
+		}
 		await this.app.fileManager.renameFile(file, newPath)
 	}
 

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -37,6 +37,8 @@ const de: Partial<Record<keyof typeof en, string>> = {
 	group_by_label: 'Gruppieren nach',
 	date_field_label: 'Datumsfeld',
 	summary_stats: 'Zusammenfassungsstatistiken',
+	card_title_field_label: 'Kartentitel-Feld',
+	renamed_with_suffix: 'Eine Notiz namens "$name" existiert bereits — gespeichert als "$final"',
 	no_summary_stats: 'Noch keine Statistiken',
 	add_stat: 'Statistik hinzufügen',
 	stat_label: 'Beschriftung',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -35,6 +35,8 @@ const en = {
 	group_by_label: 'Group by',
 	date_field_label: 'Date field',
 	summary_stats: 'Summary statistics',
+	card_title_field_label: 'Card title field',
+	renamed_with_suffix: 'A note named "$name" already exists — saved as "$final"',
 	no_summary_stats: 'No statistics yet',
 	add_stat: 'Add statistic',
 	stat_label: 'Label',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -37,6 +37,8 @@ const es: Partial<Record<keyof typeof en, string>> = {
 	group_by_label: 'Agrupar por',
 	date_field_label: 'Campo de fecha',
 	summary_stats: 'Estadísticas de resumen',
+	card_title_field_label: 'Campo de título de la tarjeta',
+	renamed_with_suffix: 'Ya existe una nota llamada "$name" — guardada como "$final"',
 	no_summary_stats: 'Aún no hay estadísticas',
 	add_stat: 'Añadir estadística',
 	stat_label: 'Etiqueta',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -37,6 +37,8 @@ const fr: Partial<Record<keyof typeof en, string>> = {
 	group_by_label: 'Grouper par',
 	date_field_label: 'Champ de date',
 	summary_stats: 'Statistiques de synthèse',
+	card_title_field_label: 'Champ de titre de la carte',
+	renamed_with_suffix: 'Une note nommée "$name" existe déjà — enregistrée sous "$final"',
 	no_summary_stats: 'Aucune statistique pour le moment',
 	add_stat: 'Ajouter une statistique',
 	stat_label: 'Libellé',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -37,6 +37,8 @@ const ja: Partial<Record<keyof typeof en, string>> = {
 	group_by_label: 'グループ化条件',
 	date_field_label: '日付フィールド',
 	summary_stats: '集計統計',
+	card_title_field_label: 'カードタイトルのフィールド',
+	renamed_with_suffix: '「$name」という名前のノートは既に存在します — 「$final」として保存しました',
 	no_summary_stats: '統計はまだありません',
 	add_stat: '統計を追加',
 	stat_label: 'ラベル',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -37,6 +37,8 @@ const ptBR: Partial<Record<keyof typeof en, string>> = {
 	group_by_label: 'Agrupar por',
 	date_field_label: 'Campo de data',
 	summary_stats: 'Estatísticas de resumo',
+	card_title_field_label: 'Campo de título do card',
+	renamed_with_suffix: 'Já existe uma nota chamada "$name" — salva como "$final"',
 	no_summary_stats: 'Nenhuma estatística ainda',
 	add_stat: 'Adicionar estatística',
 	stat_label: 'Rótulo',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -37,6 +37,8 @@ const zh: Partial<Record<keyof typeof en, string>> = {
 	group_by_label: '分组条件',
 	date_field_label: '日期字段',
 	summary_stats: '汇总统计',
+	card_title_field_label: '卡片标题字段',
+	renamed_with_suffix: '已存在名为“$name”的笔记 — 已保存为“$final”',
 	no_summary_stats: '暂无统计',
 	add_stat: '添加统计',
 	stat_label: '标签',

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,10 @@ export interface ViewConfig {
 	boardHideNoValue?: boolean
 	galleryCoverField?: string
 	galleryCardSize?: 'small' | 'medium' | 'large'
+	// Column shown as the card title on Calendar/Board/Timeline instead of the
+	// filename (#41): lets recurring events share a clean display name while
+	// each row keeps a unique file
+	cardTitleField?: string
 	calendarDateField?: string
 	calendarEndDateField?: string
 	calendarViewMode?: 'month' | 'week'

--- a/tests/filter-utils.test.ts
+++ b/tests/filter-utils.test.ts
@@ -9,6 +9,7 @@ import {
 	toggleMultiValue,
 	filterConfigsToPills,
 	computeSummaryStat,
+	getCardTitle,
 	isMultiValueFilter,
 	ActiveFilter,
 	MULTI_VALUE_SEPARATOR,
@@ -474,5 +475,24 @@ describe('computeSummaryStat', () => {
 
 	it('returns the full count when the condition value is empty', () => {
 		expect(computeSummaryStat(rows, { id: '4', label: 'All', columnId: 'status', operator: 'is', value: '' }, schema)).toBe(3)
+	})
+})
+
+// ── getCardTitle (#41) ───────────────────────────────────────────────────────
+
+describe('getCardTitle', () => {
+	it('returns the filename when no display field is set', () => {
+		expect(getCardTitle(makeRow({ _title: 'Weekly Meeting 3' }), undefined)).toBe('Weekly Meeting 3')
+	})
+
+	it('returns the display field value when set and non-empty', () => {
+		const row = makeRow({ _title: 'Weekly Meeting 3', event: 'Weekly Meeting' })
+		expect(getCardTitle(row, 'event')).toBe('Weekly Meeting')
+	})
+
+	it('falls back to the filename when the display value is empty or missing', () => {
+		expect(getCardTitle(makeRow({ _title: 'Note A', event: '' }), 'event')).toBe('Note A')
+		expect(getCardTitle(makeRow({ _title: 'Note B', event: null }), 'event')).toBe('Note B')
+		expect(getCardTitle(makeRow({ _title: 'Note C' }), 'missing')).toBe('Note C')
 	})
 })


### PR DESCRIPTION
## Summary
Rows are files, so two rows cannot share a filename — but recurring events deserve a clean shared display name. Two changes deliver the combination promised in the issue discussion:

- New `cardTitleField` on the view config: Calendar, Board and Timeline cards can display any column as their title instead of the filename (picker in each view's menu, "Name" as the default, falling back to the filename when the value is empty). Tooltips and context menus keep the real filename so files stay traceable.
- `renameNote` now auto-suffixes to the first free name and shows a notice when the target title already exists, instead of failing silently on the filesystem collision.

Locale strings in seven languages; three new unit tests (214 total).

Closes #41